### PR TITLE
refactor: allow passing api base url as environment variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 VUE_APP_BASE_URL=https://acdh-oeaw.github.io
+VUE_APP_MMP_API_BASE_URL=https://mmp.acdh-dev.oeaw.ac.at

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@types/geojson": "^7946.0.10",
         "@types/leaflet": "1.7.11",
         "@types/leaflet.markercluster": "1.5.1",
+        "@types/node": "^16.18.3",
         "@typescript-eslint/eslint-plugin": "^5.38.1",
         "@typescript-eslint/parser": "^5.38.1",
         "@vue/cli-plugin-babel": "^5.0.8",
@@ -4244,9 +4245,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.5.tgz",
-      "integrity": "sha512-3JRwhbjI+cHLAkUorhf8RnqUbFXajvzX4q6fMn5JwkgtuwfYtRQYI3u4V92vI6NJuTsbBQWWh3RZjFsuevyMGQ==",
+      "version": "16.18.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.3.tgz",
+      "integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -20486,9 +20487,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.5.tgz",
-      "integrity": "sha512-3JRwhbjI+cHLAkUorhf8RnqUbFXajvzX4q6fMn5JwkgtuwfYtRQYI3u4V92vI6NJuTsbBQWWh3RZjFsuevyMGQ==",
+      "version": "16.18.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.3.tgz",
+      "integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@types/geojson": "^7946.0.10",
     "@types/leaflet": "1.7.11",
     "@types/leaflet.markercluster": "1.5.1",
+    "@types/node": "^16.18.3",
     "@typescript-eslint/eslint-plugin": "^5.38.1",
     "@typescript-eslint/parser": "^5.38.1",
     "@vue/cli-plugin-babel": "^5.0.8",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -46,7 +46,7 @@ import type {
 
 //
 
-const baseUrl = 'https://mmp.acdh-dev.oeaw.ac.at/';
+const baseUrl = process.env.VUE_APP_MMP_API_BASE_URL
 
 const baseUrls = {
   autocomplete: new URL('archiv-ac/', baseUrl),

--- a/src/components/AuthorDetail.vue
+++ b/src/components/AuthorDetail.vue
@@ -139,10 +139,10 @@ export default {
         this.loading = true;
 
         const urls = [
-          `https://mmp.acdh-dev.oeaw.ac.at/api/autor/${params.id}/?format=json`,
-          `https://mmp.acdh-dev.oeaw.ac.at/api/usecase/?has_stelle__text__autor=${params.id}&format=json`,
-          `https://mmp.acdh-dev.oeaw.ac.at/api/stelle/?text__autor=${params.id}&format=json&has_usecase=${this.hasUsecase}`,
-          `https://mmp.acdh-dev.oeaw.ac.at/api/keyword/?rvn_stelle_key_word_keyword__text__autor=${params.id}&format=json&has_usecase=${this.hasUsecase}`,
+          `${process.env.VUE_APP_MMP_API_BASE_URL}/api/autor/${params.id}/?format=json`,
+          `${process.env.VUE_APP_MMP_API_BASE_URL}/api/usecase/?has_stelle__text__autor=${params.id}&format=json`,
+          `${process.env.VUE_APP_MMP_API_BASE_URL}/api/stelle/?text__autor=${params.id}&format=json&has_usecase=${this.hasUsecase}`,
+          `${process.env.VUE_APP_MMP_API_BASE_URL}/api/keyword/?rvn_stelle_key_word_keyword__text__autor=${params.id}&format=json&has_usecase=${this.hasUsecase}`,
         ];
         const prefetched = this.$store.state.fetchedResults[urls.toString()];
 

--- a/src/components/CaseStudy.vue
+++ b/src/components/CaseStudy.vue
@@ -136,8 +136,8 @@ export default {
     const id = this.id || this.$route.params.id;
 
     const urls = [
-      `https://mmp.acdh-dev.oeaw.ac.at/api/usecase/${id}?format=json`,
-      `https://mmp.acdh-dev.oeaw.ac.at/archiv/usecase-timetable-data/${id}`,
+      `${process.env.VUE_APP_MMP_API_BASE_URL}/api/usecase/${id}?format=json`,
+      `${process.env.VUE_APP_MMP_API_BASE_URL}/archiv/usecase-timetable-data/${id}`,
     ];
 
     const prefetched = this.$store.state.fetchedResults[urls.toString()];

--- a/src/components/CompareAuthors.vue
+++ b/src/components/CompareAuthors.vue
@@ -495,12 +495,12 @@ export default {
         const authors = query.Author?.split('+') || [];
         if (authors.length >= 2) {
           this.selectedAuthors = authors;
-          fetch(`https://mmp.acdh-dev.oeaw.ac.at/api/autor/?format=json&ids=${authors.join(',')}`)
+          fetch(`${process.env.VUE_APP_MMP_API_BASE_URL}/api/autor/?format=json&ids=${authors.join(',')}`)
             .then((res) => res.json())
             .then((authorJsonRes) => {
               const authorData = authorJsonRes.results;
               console.log('Author Data', authorData);
-              Promise.all(authors.map((x) => fetch(`https://mmp.acdh-dev.oeaw.ac.at/archiv/keyword-data/?has_usecase=${this.hasUsecase}&rvn_stelle_key_word_keyword__text__autor=${x}`)))
+              Promise.all(authors.map((x) => fetch(`${process.env.VUE_APP_MMP_API_BASE_URL}/archiv/keyword-data/?has_usecase=${this.hasUsecase}&rvn_stelle_key_word_keyword__text__autor=${x}`)))
                 .then((res) => {
                   Promise.all(res.map((x) => x.json()))
                     .then((jsonRes) => {

--- a/src/components/GraphWrapperBeta.vue
+++ b/src/components/GraphWrapperBeta.vue
@@ -467,7 +467,7 @@ export default {
   watch: {
     '$route.query': {
       handler(query) {
-        let address = `https://mmp.acdh-dev.oeaw.ac.at/archiv/keyword-data/?has_usecase=${this.hasUsecase}`;
+        let address = `${process.env.VUE_APP_MMP_API_BASE_URL}/archiv/keyword-data/?has_usecase=${this.hasUsecase}`;
         const terms = {
           Author: 'rvn_stelle_key_word_keyword__text__autor',
           Passage: 'rvn_stelle_key_word_keyword',

--- a/src/components/InterfaceWrapper.vue
+++ b/src/components/InterfaceWrapper.vue
@@ -423,7 +423,7 @@ export default {
               const idCount = ids.length;
               this.skeletonChips += idCount;
               ids = ids.join(',');
-              fetch(`https://mmp.acdh-dev.oeaw.ac.at/api/${apiParams[cat].url}/?ids=${ids}`)
+              fetch(`${process.env.VUE_APP_MMP_API_BASE_URL}/api/${apiParams[cat].url}/?ids=${ids}`)
                 .then((res) => res.json())
                 .then((res) => {
                   console.log('Query', cat, res);
@@ -453,11 +453,11 @@ export default {
       if (!val || val.length < 1) return;
       const urls = {};
       const filters = this.$store.state.searchFilters;
-      if (filters.author) urls.Author = `https://mmp.acdh-dev.oeaw.ac.at/archiv-ac/autor-autocomplete/?q=${val}`;
-      if (filters.passage) urls.Passage = `https://mmp.acdh-dev.oeaw.ac.at/archiv-ac/stelle-autocomplete/?q=${val}`;
-      if (Object.values(filters.keyword).some((x) => x)) urls.Keyword = `https://mmp.acdh-dev.oeaw.ac.at/archiv-ac/keyword-autocomplete/?q=${val}`;
-      if (filters.usecase) urls['Use Case'] = `https://mmp.acdh-dev.oeaw.ac.at/archiv-ac/usecase-autocomplete/?q=${val}`;
-      if (filters.place) urls.Place = `https://mmp.acdh-dev.oeaw.ac.at/archiv-ac/ort-autocomplete/?q=${val}`;
+      if (filters.author) urls.Author = `${process.env.VUE_APP_MMP_API_BASE_URL}/archiv-ac/autor-autocomplete/?q=${val}`;
+      if (filters.passage) urls.Passage = `${process.env.VUE_APP_MMP_API_BASE_URL}/archiv-ac/stelle-autocomplete/?q=${val}`;
+      if (Object.values(filters.keyword).some((x) => x)) urls.Keyword = `${process.env.VUE_APP_MMP_API_BASE_URL}/archiv-ac/keyword-autocomplete/?q=${val}`;
+      if (filters.usecase) urls['Use Case'] = `${process.env.VUE_APP_MMP_API_BASE_URL}/archiv-ac/usecase-autocomplete/?q=${val}`;
+      if (filters.place) urls.Place = `${process.env.VUE_APP_MMP_API_BASE_URL}/archiv-ac/ort-autocomplete/?q=${val}`;
 
       const labels = ['Author', 'Passage', 'Keyword', 'Use Case', 'Place'];
       const prefetched = this.$store.state.fetchedResults[JSON.stringify(urls)];

--- a/src/components/KeywordDetail.vue
+++ b/src/components/KeywordDetail.vue
@@ -199,7 +199,7 @@ export default {
         const ids = params.id.toString(10).split('+');
 
         // Keywords
-        let urls = ids.map((x) => `https://mmp.acdh-dev.oeaw.ac.at/api/keyword/${x}/?format=json`);
+        let urls = ids.map((x) => `${process.env.VUE_APP_MMP_API_BASE_URL}/api/keyword/${x}/?format=json`);
         let prefetched = this.$store.state.fetchedResults[urls.toString()];
         if (prefetched) {
           this.data.keywords = prefetched;
@@ -225,7 +225,7 @@ export default {
         }
 
         // Overtime
-        urls = ids.map((x) => `https://mmp.acdh-dev.oeaw.ac.at/archiv/keyword/century/${x}`);
+        urls = ids.map((x) => `${process.env.VUE_APP_MMP_API_BASE_URL}/archiv/keyword/century/${x}`);
         prefetched = this.$store.state.fetchedResults[urls.toString()];
         if (prefetched) {
           this.data.overtime = prefetched;
@@ -252,9 +252,9 @@ export default {
 
         // Else
         urls = [
-          `https://mmp.acdh-dev.oeaw.ac.at/archiv/keyword-data/?ids=${ids.join(',')}`,
-          `https://mmp.acdh-dev.oeaw.ac.at/api/stelle/?format=json&has_usecase=${this.hasUsecase}`,
-          'https://mmp.acdh-dev.oeaw.ac.at/api/spatialcoverage/?format=json',
+          `${process.env.VUE_APP_MMP_API_BASE_URL}/archiv/keyword-data/?ids=${ids.join(',')}`,
+          `${process.env.VUE_APP_MMP_API_BASE_URL}/api/stelle/?format=json&has_usecase=${this.hasUsecase}`,
+          `${process.env.VUE_APP_MMP_API_BASE_URL}/api/spatialcoverage/?format=json`,
         ];
 
         ids.forEach((x) => {

--- a/src/components/KeywordListItem.vue
+++ b/src/components/KeywordListItem.vue
@@ -40,7 +40,7 @@ export default {
   mixins: [helpers],
   mounted() {
     const { intersect } = this.$store.state.apiParams;
-    let url = `https://mmp.acdh-dev.oeaw.ac.at/api/stelle/?${intersect ? 'key_word_and' : 'key_word'}=${this.siblingNode}&has_usecase=${this.hasUsecase}`;
+    let url = `${process.env.VUE_APP_MMP_API_BASE_URL}/api/stelle/?${intersect ? 'key_word_and' : 'key_word'}=${this.siblingNode}&has_usecase=${this.hasUsecase}`;
     this.parentNodes.forEach((x) => {
       url += intersect ? `&key_word_and=${x}` : `&key_word=${x}`;
     });

--- a/src/components/Leaflet.vue
+++ b/src/components/Leaflet.vue
@@ -926,7 +926,7 @@ export default {
 
         const study = this.$route.query['Use Case'];
         if (study) {
-          const url = `https://mmp.acdh-dev.oeaw.ac.at/api/usecase/${study}?format=json`;
+          const url = `${process.env.VUE_APP_MMP_API_BASE_URL}/api/usecase/${study}?format=json`;
           fetch(url)
             .then((res) => res.json())
             .then((jsonRes) => {

--- a/src/components/List.vue
+++ b/src/components/List.vue
@@ -133,7 +133,7 @@ export default {
         Place: 'text__ort',
       };
 
-      let address = `https://mmp.acdh-dev.oeaw.ac.at/api/stelle/?format=json&limit=${this.pagination.limit}&offset=${this.pagination.offset}&has_usecase=${this.hasUsecase}`;
+      let address = `${process.env.VUE_APP_MMP_API_BASE_URL}/api/stelle/?format=json&limit=${this.pagination.limit}&offset=${this.pagination.offset}&has_usecase=${this.hasUsecase}`;
       const props = [
         this.author,
         this.passage,

--- a/src/components/ListAll.vue
+++ b/src/components/ListAll.vue
@@ -166,7 +166,7 @@ export default {
     fetchEntities(tabIndex) {
       this.tabs[tabIndex].loading = true;
       const names = ['name', 'zitat', 'stichwort', 'title', 'name'];
-      const address = `https://mmp.acdh-dev.oeaw.ac.at/api/${this.tabs[tabIndex].api}/?${names[tabIndex]}=${this.tabs[tabIndex].filter}&${names[tabIndex]}_lookup=icontains&offset=${this.tabs[tabIndex].pagination.offset}&limit=${this.tabs[tabIndex].pagination.limit}&format=json`;
+      const address = `${process.env.VUE_APP_MMP_API_BASE_URL}/api/${this.tabs[tabIndex].api}/?${names[tabIndex]}=${this.tabs[tabIndex].filter}&${names[tabIndex]}_lookup=icontains&offset=${this.tabs[tabIndex].pagination.offset}&limit=${this.tabs[tabIndex].pagination.limit}&format=json`;
       const prefetched = this.$store.state.fetchedResults[address];
       if (prefetched) {
         this.tabs[tabIndex].items = prefetched.results;

--- a/src/components/MapWrapper.vue
+++ b/src/components/MapWrapper.vue
@@ -47,8 +47,8 @@ export default {
     '$route.query': {
       handler(query) {
         let urls = [
-          'https://mmp.acdh-dev.oeaw.ac.at/api/spatialcoverage/?format=json',
-          'https://mmp.acdh-dev.oeaw.ac.at/api/cones/?format=json',
+          `${process.env.VUE_APP_MMP_API_BASE_URL}/api/spatialcoverage/?format=json`,
+          `${process.env.VUE_APP_MMP_API_BASE_URL}/api/cones/?format=json`,
         ];
         const blankUrls = urls;
 
@@ -80,7 +80,7 @@ export default {
                   // prevents fetching every coverage if no other filters are applied
                   urls = urls.map((x) => `${x}&id=0`);
                 }
-                urls.push(`https://mmp.acdh-dev.oeaw.ac.at/api/ort-geojson/?format=json&ids=${prop}`);
+                urls.push(`${process.env.VUE_APP_MMP_API_BASE_URL}/api/ort-geojson/?format=json&ids=${prop}`);
               } else {
                 urls = urls.map((url) => `${url}&${Object.values(terms)[i]}=${prop}`);
               }
@@ -113,8 +113,8 @@ export default {
               // prevents fetching every coverage if no other filters are applied
               urls = urls.map((x) => `${x}&id=0`);
             }
-            urls.push(`https://mmp.acdh-dev.oeaw.ac.at/api/ort-geojson/?format=json&ids=${query.Place.split('+').join(',')}`);
-          } else urls.push('https://mmp.acdh-dev.oeaw.ac.at/api/ort/?format=json&id=0');
+            urls.push(`${process.env.VUE_APP_MMP_API_BASE_URL}/api/ort-geojson/?format=json&ids=${query.Place.split('+').join(',')}`);
+          } else urls.push(`${process.env.VUE_APP_MMP_API_BASE_URL}/api/ort/?format=json&id=0`);
         }
 
         console.log('map urls', urls);

--- a/src/components/PassageDetail.vue
+++ b/src/components/PassageDetail.vue
@@ -136,7 +136,7 @@ export default {
       handler(params) {
         console.log(params);
         this.loading = true;
-        const address = `https://mmp.acdh-dev.oeaw.ac.at/api/stelle/${params.id}/?format=json`;
+        const address = `${process.env.VUE_APP_MMP_API_BASE_URL}/api/stelle/${params.id}/?format=json`;
         const prefetched = this.$store.state.fetchedResults[address];
 
         if (prefetched) {

--- a/src/components/PlaceDetail.vue
+++ b/src/components/PlaceDetail.vue
@@ -95,9 +95,9 @@ export default {
         console.log('place params', params);
         this.loading = true;
         const urls = [
-          `https://mmp.acdh-dev.oeaw.ac.at/api/ort/${params.id}/?format=json`,
-          `https://mmp.acdh-dev.oeaw.ac.at/api/text/?ort=${params.id}&format=json&has_usecase=${this.hasUsecase}`,
-          `https://mmp.acdh-dev.oeaw.ac.at/api/autor/?ort=${params.id}&format=json&has_usecase=${this.hasUsecase}`,
+          `${process.env.VUE_APP_MMP_API_BASE_URL}/api/ort/${params.id}/?format=json`,
+          `${process.env.VUE_APP_MMP_API_BASE_URL}/api/text/?ort=${params.id}&format=json&has_usecase=${this.hasUsecase}`,
+          `${process.env.VUE_APP_MMP_API_BASE_URL}/api/autor/?ort=${params.id}&format=json&has_usecase=${this.hasUsecase}`,
         ];
         const prefetched = this.$store.state.fetchedResults[urls.toString()];
 

--- a/src/components/SpatialDetail.vue
+++ b/src/components/SpatialDetail.vue
@@ -98,7 +98,7 @@ export default {
         this.data = [];
         arr.forEach((param) => {
           this.loading = true;
-          const address = `https://mmp.acdh-dev.oeaw.ac.at/api/spatialcoverage/${param}`;
+          const address = `${process.env.VUE_APP_MMP_API_BASE_URL}/api/spatialcoverage/${param}`;
           const prefetched = this.$store.state.fetchedResults[address];
           if (prefetched) {
             this.data.push(prefetched);

--- a/src/components/Studies.vue
+++ b/src/components/Studies.vue
@@ -81,8 +81,8 @@ export default {
       if (!val || val.length < 1) return;
       const urls = {};
       const filters = this.$store.state.searchFilters;
-      if (filters.author) urls.Author = `https://mmp.acdh-dev.oeaw.ac.at/archiv-ac/autor-autocomplete/?q=${val}`;
-      if (Object.values(filters.keyword).some((x) => x)) urls.Keyword = `https://mmp.acdh-dev.oeaw.ac.at/archiv-ac/keyword-autocomplete/?q=${val}`;
+      if (filters.author) urls.Author = `${process.env.VUE_APP_MMP_API_BASE_URL}/archiv-ac/autor-autocomplete/?q=${val}`;
+      if (Object.values(filters.keyword).some((x) => x)) urls.Keyword = `${process.env.VUE_APP_MMP_API_BASE_URL}/archiv-ac/keyword-autocomplete/?q=${val}`;
 
       // const labels = ['Author', 'Keyword'];
       const prefetched = this.$store.state.fetchedResults[JSON.stringify(urls)];
@@ -122,7 +122,7 @@ export default {
     studyAuto: {
       handler(val) {
         console.log('studyAuto', val);
-        let url = 'https://mmp.acdh-dev.oeaw.ac.at/api/usecase/?format=json';
+        let url = `${process.env.VUE_APP_MMP_API_BASE_URL}/api/usecase/?format=json`;
         const apiParams = {
           author: 'has_stelle__text__autor',
           keyword: 'has_stelle__key_word',
@@ -149,7 +149,7 @@ export default {
     },
   },
   mounted() {
-    const address = 'https://mmp.acdh-dev.oeaw.ac.at/api/usecase/?format=json';
+    const address = `${process.env.VUE_APP_MMP_API_BASE_URL}/api/usecase/?format=json`;
     const prefetched = this.$store.state.fetchedResults[address];
 
     if (prefetched) {

--- a/src/components/WordCloudWrapper.vue
+++ b/src/components/WordCloudWrapper.vue
@@ -299,8 +299,8 @@ export default {
         this.loading = 2;
         this.words = [];
         let urls = [
-          'https://mmp.acdh-dev.oeaw.ac.at/archiv/nlp-data/?',
-          'https://mmp.acdh-dev.oeaw.ac.at/archiv/kw-stelle/?',
+          `${process.env.VUE_APP_MMP_API_BASE_URL}/archiv/nlp-data/?`,
+          `${process.env.VUE_APP_MMP_API_BASE_URL}/archiv/kw-stelle/?`,
         ];
 
         const terms = {


### PR DESCRIPTION
this allows configuring the api base url via `VUE_APP_MMP_API_BASE_URL` environment variable, which can be useful to test changes to the backend locally.