### PR TITLE
fix: add new geojson layers endpoint to api client

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -9,6 +9,8 @@ import type {
   AuthorNormalized,
   Event,
   EventNormalized,
+  GeojsonLayer,
+  GeojsonLayerNormalized,
   Keyword,
   KeywordNormalized,
   KeywordType,
@@ -852,8 +854,9 @@ export namespace GetUseCases {
       has_stelle__key_word?: Array<Keyword['id']>;
     };
   export type Response = PaginatedResponse<
-    Omit<UseCase, 'knightlab_stoy_map'> & {
+    Omit<UseCase, 'knightlab_stoy_map' | 'layer'> & {
       knightlab_stoy_map: Array<StoryNormalized>;
+      layer: Array<GeojsonLayerNormalized>;
     }
   >;
 }
@@ -876,6 +879,34 @@ export function getUseCaseById(
   params: GetUseCaseById.PathParams
 ): Promise<GetUseCaseById.Response> {
   const url = createUrl({ baseUrl: baseUrls.api, pathname: `usecase/${params.id}` });
+  return request(url, options);
+}
+
+export namespace GetGeojsonLayers {
+  export type SearchParams = LimitOffsetPaginationSearchParams & {
+    use_case?: Array<UseCase['id']>;
+  };
+  export type Response = PaginatedResponse<GeojsonLayerNormalized>;
+}
+
+export function getGeojsonLayers(
+  searchParams: GetGeojsonLayers.SearchParams
+): Promise<GetGeojsonLayers.Response> {
+  const url = createUrl({ baseUrl: baseUrls.api, pathname: 'layers/', searchParams });
+  return request(url, options);
+}
+
+export namespace GetGeojsonLayerById {
+  export type PathParams = {
+    id: GeojsonLayer['id'];
+  };
+  export type Response = GeojsonLayerNormalized;
+}
+
+export function getGeojsonLayerById(
+  params: GetGeojsonLayerById.PathParams
+): Promise<GetGeojsonLayerById.Response> {
+  const url = createUrl({ baseUrl: baseUrls.api, pathname: `layers/${params.id}` });
   return request(url, options);
 }
 

--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -46,6 +46,7 @@ const resources = [
   'autocomplete-place-type',
   'autocomplete-place-category',
   'event',
+  'geojson-layer',
   'geojson-place',
   'geojson-fuzzy-place',
   'geojson-cone',
@@ -300,6 +301,32 @@ export function useUseCaseTimeTableById(
     queryKey: createKey('use-case', 'by-id', params, 'timetable'),
     queryFn: ({ queryKey: [, , params] }) => {
       return api.getUseCaseTimetableById(assertId(params));
+    },
+    ...getQueryOptions(options),
+  });
+}
+
+export function useGeojsonLayers(
+  searchParams: MaybeRef<Partial<api.GetGeojsonLayers.SearchParams>>,
+  options?: Options
+) {
+  return useQuery({
+    queryKey: createKey('geojson-layer', 'list', searchParams),
+    queryFn: ({ queryKey: [, , searchParams] }) => {
+      return api.getGeojsonLayers(searchParams);
+    },
+    ...getQueryOptions(options),
+  });
+}
+
+export function useGeojsonLayerById(
+  params: MaybeRef<Partial<api.GetGeojsonLayerById.PathParams>>,
+  options?: Options
+) {
+  return useQuery({
+    queryKey: createKey('geojson-layer', 'by-id', params),
+    queryFn: ({ queryKey: [, , params] }) => {
+      return api.getGeojsonLayerById(assertId(params));
     },
     ...getQueryOptions(options),
   });

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -1,4 +1,4 @@
-import type { GeometryCollection, Point, Polygon } from 'geojson';
+import type { FeatureCollection, GeometryCollection, Point, Polygon } from 'geojson';
 
 import type { Normalized } from '@/api/types';
 
@@ -20,11 +20,22 @@ export type UseCase = {
   /** Knightlab Story Maps. */
   knightlab_stoy_map: Array<Story>;
 
-  /** Additional map layer. Needs to match predefined allowed layer names, e.g. '800'. */
-  custom_layer?: string | null;
+  /** Additional GeoJSON layers associated with case study. */
+  layer: Array<GeojsonLayer>;
 };
 
-export type UseCaseNormalized = Normalized<UseCase, 'knightlab_stoy_map'>;
+export type UseCaseNormalized = Normalized<UseCase, 'knightlab_stoy_map' | 'layer'>;
+
+export type GeojsonLayer = {
+  id: number;
+
+  title: string;
+  attribution: string;
+  description?: string | null;
+  data: FeatureCollection;
+};
+
+export type GeojsonLayerNormalized = GeojsonLayer;
 
 export type Author = Omit<
   {


### PR DESCRIPTION
this adds newly added endpoints to the api client to retrieve additional geojson layers related to a case study.

cf. https://github.com/acdh-oeaw/mmp/issues/150