### PR TITLE
fix: add generic autocomplete endpoint to api client

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -45,6 +45,7 @@ import type {
   PageNumberPaginationSearchParams,
   PaginatedGeoJsonResponse,
   PaginatedResponse,
+  ResourceKind,
   SortableSearchParams,
   StringLookupSearchParams,
 } from '@/api/types';
@@ -54,15 +55,41 @@ import type {
 const baseUrl = import.meta.env.VITE_APP_MMP_API_BASE_URL;
 
 const baseUrls = {
-  autoComplete: new URL('archiv-ac/', baseUrl),
-  archiv: new URL('archiv/', baseUrl),
   api: new URL('api/', baseUrl),
+  archiv: new URL('archiv/', baseUrl),
+  archivAutoComplete: new URL('archiv-ac/', baseUrl),
+  autoComplete: new URL('ac/', baseUrl),
   vocabsAutoComplete: new URL('vocabs-ac/', baseUrl),
 };
 
 const options: RequestOptions = { responseType: 'json' };
 
 //
+
+export namespace GetAutoComplete {
+  export type SearchParams = {
+    /** Must be at least 3 characters. */
+    q: string;
+    kind?: Array<ResourceKind>;
+  };
+  export type Response = { q: string } & PaginatedResponse<{
+    id: number;
+    kind: ResourceKind;
+    app_name: string;
+    label: string;
+  }>;
+}
+
+export function getAutoComplete(
+  searchParams: GetAutoComplete.SearchParams
+): Promise<GetAutoComplete.Response> {
+  const url = createUrl({
+    baseUrl: baseUrls.autoComplete,
+    pathname: '',
+    searchParams,
+  });
+  return request(url, options);
+}
 
 export namespace GetAuthorsAutoComplete {
   export type SearchParams = AutoComplete.SearchParams;
@@ -73,7 +100,7 @@ export function getAuthorsAutoComplete(
   searchParams: GetAuthorsAutoComplete.SearchParams
 ): Promise<GetAuthorsAutoComplete.Response> {
   const url = createUrl({
-    baseUrl: baseUrls.autoComplete,
+    baseUrl: baseUrls.archivAutoComplete,
     pathname: 'autor-autocomplete/',
     searchParams,
   });
@@ -89,7 +116,7 @@ export function getKeywordsAutoComplete(
   searchParams: GetKeywordsAutoComplete.SearchParams
 ): Promise<GetKeywordsAutoComplete.Response> {
   const url = createUrl({
-    baseUrl: baseUrls.autoComplete,
+    baseUrl: baseUrls.archivAutoComplete,
     pathname: 'keyword-autocomplete/',
     searchParams,
   });
@@ -106,7 +133,7 @@ export function getRegionKeywordsAutoComplete(
   searchParams: GetRegionKeywordsAutoComplete.SearchParams
 ): Promise<GetRegionKeywordsAutoComplete.Response> {
   const url = createUrl({
-    baseUrl: baseUrls.autoComplete,
+    baseUrl: baseUrls.archivAutoComplete,
     pathname: 'region-autocomplete/',
     searchParams,
   });
@@ -123,7 +150,7 @@ export function getEthnonymKeywordsAutoComplete(
   searchParams: GetEthnonymKeywordsAutoComplete.SearchParams
 ): Promise<GetEthnonymKeywordsAutoComplete.Response> {
   const url = createUrl({
-    baseUrl: baseUrls.autoComplete,
+    baseUrl: baseUrls.archivAutoComplete,
     pathname: 'ethnonym-autocomplete/',
     searchParams,
   });
@@ -140,7 +167,7 @@ export function getNameKeywordsAutoComplete(
   searchParams: GetNameKeywordsAutoComplete.SearchParams
 ): Promise<GetNameKeywordsAutoComplete.Response> {
   const url = createUrl({
-    baseUrl: baseUrls.autoComplete,
+    baseUrl: baseUrls.archivAutoComplete,
     pathname: 'eigenname-autocomplete/',
     searchParams,
   });
@@ -157,7 +184,7 @@ export function getKeywordKeywordsAutoComplete(
   searchParams: GetKeywordKeywordsAutoComplete.SearchParams
 ): Promise<GetKeywordKeywordsAutoComplete.Response> {
   const url = createUrl({
-    baseUrl: baseUrls.autoComplete,
+    baseUrl: baseUrls.archivAutoComplete,
     pathname: 'schlagwort-autocomplete/',
     searchParams,
   });
@@ -173,7 +200,7 @@ export function getPlacesAutoComplete(
   searchParams: GetPlacesAutoComplete.SearchParams
 ): Promise<GetPlacesAutoComplete.Response> {
   const url = createUrl({
-    baseUrl: baseUrls.autoComplete,
+    baseUrl: baseUrls.archivAutoComplete,
     pathname: 'ort-autocomplete/',
     searchParams,
   });
@@ -189,7 +216,7 @@ export function getPassagesAutoComplete(
   searchParams: GetPassagesAutoComplete.SearchParams
 ): Promise<GetPassagesAutoComplete.Response> {
   const url = createUrl({
-    baseUrl: baseUrls.autoComplete,
+    baseUrl: baseUrls.archivAutoComplete,
     pathname: 'stelle-autocomplete/',
     searchParams,
   });
@@ -205,7 +232,7 @@ export function getTextsAutoComplete(
   searchParams: GetTextsAutoComplete.SearchParams
 ): Promise<GetTextsAutoComplete.Response> {
   const url = createUrl({
-    baseUrl: baseUrls.autoComplete,
+    baseUrl: baseUrls.archivAutoComplete,
     pathname: 'text-autocomplete/',
     searchParams,
   });
@@ -221,7 +248,7 @@ export function getUseCasesAutoComplete(
   searchParams: GetUseCasesAutoComplete.SearchParams
 ): Promise<GetUseCasesAutoComplete.Response> {
   const url = createUrl({
-    baseUrl: baseUrls.autoComplete,
+    baseUrl: baseUrls.archivAutoComplete,
     pathname: 'usecase-autocomplete/',
     searchParams,
   });
@@ -852,6 +879,12 @@ export namespace GetUseCases {
 
       /** Related keywords (AND query). */
       has_stelle__key_word?: Array<Keyword['id']>;
+
+      /** Additional GeoJSON layers associated with case study. */
+      layer?: Array<GeojsonLayer['id']>;
+
+      /** Should display labels for spatial coverages. */
+      show_labels?: boolean;
     };
   export type Response = PaginatedResponse<
     Omit<UseCase, 'knightlab_stoy_map' | 'layer'> & {
@@ -1159,8 +1192,6 @@ export type SpatialCoverageSearchParams = {
 
   stelle__text__autor__end_date_year?: number;
   stelle__text__autor__end_date_year__lookup?: DateLookupSearchParams;
-
-  show_labels?: boolean;
 };
 
 export type ConeGeojson = { id: SpatialCoverage['id'] } & Feature<
@@ -1200,14 +1231,7 @@ export function getConeGeojsonById(
 
 export type SpatialCoverageGeojson = { id: SpatialCoverage['id'] } & FeatureWithBoundingBox<
   Polygon,
-  SpatialCoverageGeojsonProperties & {
-    /**
-     * Display labels for coverage.
-     *
-     * @default true
-     */
-    show_labels: SpatialCoverage['show_labels'];
-  }
+  SpatialCoverageGeojsonProperties
 >;
 
 export namespace GetSpatialCoveragesGeojson {

--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -32,6 +32,7 @@ function getQueryOptions(options?: Options) {
 
 const resources = [
   'author',
+  'autocomplete',
   'autocomplete-author',
   'autocomplete-keyword',
   'autocomplete-keyword-region',
@@ -79,10 +80,11 @@ function createKey<
   return [resource, scope, ...args] as const;
 }
 
-function assertId<T extends { id?: string | number | null }>(params: T) {
-  const id = params.id;
-  assert(id, 'ID is required.');
-  return { ...params, id };
+function assertParams<T extends object, K extends keyof T>(params: T, keys: Array<K>) {
+  keys.forEach((key) => {
+    assert(params[key], `Param ${String(key)} is required.`);
+  });
+  return params as RequiredKeys<T, typeof keys[number]>;
 }
 
 export function useAuthors(
@@ -105,7 +107,7 @@ export function useAuthorById(
   return useQuery({
     queryKey: createKey('author', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getAuthorById(assertId(params));
+      return api.getAuthorById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -131,7 +133,7 @@ export function useKeywordById(
   return useQuery({
     queryKey: createKey('keyword', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getKeywordById(assertId(params));
+      return api.getKeywordById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -144,7 +146,7 @@ export function useKeywordByCenturyById(
   return useQuery({
     queryKey: createKey('keyword', 'by-id', params, 'century'),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getKeywordByCenturyById(assertId(params));
+      return api.getKeywordByCenturyById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -183,7 +185,7 @@ export function usePassageById(
   return useQuery({
     queryKey: createKey('passage', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getPassageById(assertId(params));
+      return api.getPassageById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -235,7 +237,7 @@ export function usePlaceById(
   return useQuery({
     queryKey: createKey('place', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getPlaceById(assertId(params));
+      return api.getPlaceById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -261,7 +263,7 @@ export function useTextById(
   return useQuery({
     queryKey: createKey('text', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getTextById(assertId(params));
+      return api.getTextById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -287,7 +289,7 @@ export function useUseCaseById(
   return useQuery({
     queryKey: createKey('use-case', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getUseCaseById(assertId(params));
+      return api.getUseCaseById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -300,7 +302,7 @@ export function useUseCaseTimeTableById(
   return useQuery({
     queryKey: createKey('use-case', 'by-id', params, 'timetable'),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getUseCaseTimetableById(assertId(params));
+      return api.getUseCaseTimetableById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -326,7 +328,7 @@ export function useGeojsonLayerById(
   return useQuery({
     queryKey: createKey('geojson-layer', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getGeojsonLayerById(assertId(params));
+      return api.getGeojsonLayerById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -352,7 +354,7 @@ export function useEventById(
   return useQuery({
     queryKey: createKey('event', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getEventById(assertId(params));
+      return api.getEventById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -378,7 +380,7 @@ export function useModelingProcessById(
   return useQuery({
     queryKey: createKey('modeling-process', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getModelingProcessById(assertId(params));
+      return api.getModelingProcessById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -417,7 +419,7 @@ export function useTextTopicRelationById(
   return useQuery({
     queryKey: createKey('text-topic-relation', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getTextTopicRelationById(assertId(params));
+      return api.getTextTopicRelationById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -443,7 +445,7 @@ export function useTopicById(
   return useQuery({
     queryKey: createKey('topic', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getTopicById(assertId(params));
+      return api.getTopicById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -469,7 +471,7 @@ export function usePlaceGeojsonById(
   return useQuery({
     queryKey: createKey('geojson-place', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getPlaceGeojsonById(assertId(params));
+      return api.getPlaceGeojsonById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -495,7 +497,7 @@ export function useFuzzyPlaceGeojsonById(
   return useQuery({
     queryKey: createKey('geojson-fuzzy-place', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getFuzzyPlaceGeojsonById(assertId(params));
+      return api.getFuzzyPlaceGeojsonById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -521,7 +523,7 @@ export function useConeGeojsonById(
   return useQuery({
     queryKey: createKey('geojson-cone', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getConeGeojsonById(assertId(params));
+      return api.getConeGeojsonById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -547,7 +549,7 @@ export function useSpatialCoverageGeojsonById(
   return useQuery({
     queryKey: createKey('geojson-spatial-coverage', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getSpatialCoverageGeojsonById(assertId(params));
+      return api.getSpatialCoverageGeojsonById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -573,7 +575,7 @@ export function useLinesPointsGeojsonById(
   return useQuery({
     queryKey: createKey('geojson-lines-points', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getLinesPointsGeojsonById(assertId(params));
+      return api.getLinesPointsGeojsonById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -599,7 +601,7 @@ export function useStoryById(
   return useQuery({
     queryKey: createKey('story', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getStoryById(assertId(params));
+      return api.getStoryById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -625,7 +627,7 @@ export function useStorySlideById(
   return useQuery({
     queryKey: createKey('story-slide', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getStorySlideById(assertId(params));
+      return api.getStorySlideById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -651,7 +653,7 @@ export function useSkosCollectionById(
   return useQuery({
     queryKey: createKey('skos-collection', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getSkosCollectionById(assertId(params));
+      return api.getSkosCollectionById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -677,7 +679,7 @@ export function useSkosConceptById(
   return useQuery({
     queryKey: createKey('skos-concept', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getSkosConceptById(assertId(params));
+      return api.getSkosConceptById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -703,7 +705,7 @@ export function useSkosConceptSchemeById(
   return useQuery({
     queryKey: createKey('skos-concept-scheme', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getSkosConceptSchemeById(assertId(params));
+      return api.getSkosConceptSchemeById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
@@ -873,6 +875,19 @@ export function usePlaceCategoriesAutoComplete(
     queryKey: createKey('autocomplete-place-category', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
       return api.getPlaceCategoriesAutoComplete(searchParams);
+    },
+    ...getQueryOptions(options),
+  });
+}
+
+export function useAutoComplete(
+  searchParams: MaybeRef<Partial<api.GetAutoComplete.SearchParams>>,
+  options?: Options
+) {
+  return useQuery({
+    queryKey: createKey('autocomplete', 'list', searchParams),
+    queryFn: ({ queryKey: [, , searchParams] }) => {
+      return api.getAutoComplete(assertParams(searchParams, ['q']));
     },
     ...getQueryOptions(options),
   });

--- a/src/api/models.ts
+++ b/src/api/models.ts
@@ -22,6 +22,13 @@ export type UseCase = {
 
   /** Additional GeoJSON layers associated with case study. */
   layer: Array<GeojsonLayer>;
+
+  /**
+   * Should display labels for spatial coverages.
+   *
+   * @default true
+   */
+  show_labels: boolean;
 };
 
 export type UseCaseNormalized = Normalized<UseCase, 'knightlab_stoy_map' | 'layer'>;
@@ -325,12 +332,6 @@ export type SpatialCoverage = {
   geom_collection?: GeometryCollection | null;
   /** Uncertainty of location on a scale from 1 (very secure) to 10 (very insecure). */
   fuzzyness: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
-  /**
-   * Display labels for coverage.
-   *
-   * @default true
-   */
-  show_labels: boolean;
 
   /** Comment. */
   kommentar?: string | null;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -85,3 +85,5 @@ export type FeatureWithBoundingBox<
 > = Feature<G, P> & {
   bbox: [number, number, number, number];
 };
+
+export type ResourceKind = 'autor' | 'ort' | 'text' | 'stelle' | 'keyword' | 'geojsonlayer';


### PR DESCRIPTION
this adds a new `/ac` autocomplete endpoint to the api client, which accepts an optional list of resource types to query (`autor`, `ort`, `stelle`, `text`, `keyword`).

note that currently a `q` param is required to have a minimum length of 3 characters.

cf. https://github.com/acdh-oeaw/mmp/issues/152