### PR TITLE
fix: use correct lookup search params, change usecase to casestudy

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -72,11 +72,12 @@ export namespace GetAutoComplete {
     q: string;
     kind?: Array<ResourceKind>;
   };
-  export type Response = { q: string } & PaginatedResponse<{
+  export type Response = { q: string; filter_on: Array<ResourceKind> } & PaginatedResponse<{
     id: number;
     kind: ResourceKind;
     app_name: string;
     label: string;
+    url: string;
   }>;
 }
 
@@ -239,14 +240,14 @@ export function getTextsAutoComplete(
   return request(url, options);
 }
 
-export namespace GetUseCasesAutoComplete {
+export namespace GetCaseStudiesAutoComplete {
   export type SearchParams = AutoComplete.SearchParams;
   export type Response = AutoComplete.Response;
 }
 
-export function getUseCasesAutoComplete(
-  searchParams: GetUseCasesAutoComplete.SearchParams
-): Promise<GetUseCasesAutoComplete.Response> {
+export function getCaseStudiesAutoComplete(
+  searchParams: GetCaseStudiesAutoComplete.SearchParams
+): Promise<GetCaseStudiesAutoComplete.Response> {
   const url = createUrl({
     baseUrl: baseUrls.archivAutoComplete,
     pathname: 'usecase-autocomplete/',
@@ -315,43 +316,43 @@ export namespace GetAuthors {
       has_usecase?: boolean;
 
       gnd_id?: string;
-      gnd_id__lookup?: StringLookupSearchParams;
+      gnd_id_lookup?: StringLookupSearchParams;
 
       name?: string;
-      name__lookup?: StringLookupSearchParams;
+      name_lookup?: StringLookupSearchParams;
 
       name_lat?: string;
-      name_lat__lookup?: StringLookupSearchParams;
+      name_lat_lookup?: StringLookupSearchParams;
 
       name_en?: string;
-      name_en__lookup?: StringLookupSearchParams;
+      name_en_lookup?: StringLookupSearchParams;
 
       name_fr?: string;
-      name_fr__lookup?: StringLookupSearchParams;
+      name_fr_lookup?: StringLookupSearchParams;
 
       name_it?: string;
-      name_it__lookup?: StringLookupSearchParams;
+      name_it_lookup?: StringLookupSearchParams;
 
       jahrhundert?: string;
-      jahrhundert__lookup?: StringLookupSearchParams;
+      jahrhundert_lookup?: StringLookupSearchParams;
 
       start_date?: string;
-      start_date__lookup?: DateLookupSearchParams;
+      start_date_lookup?: DateLookupSearchParams;
 
       start_date_year?: number;
-      start_date_year__lookup?: DateLookupSearchParams;
+      start_date_year_lookup?: DateLookupSearchParams;
 
       end_date?: string;
-      end_date__lookup?: DateLookupSearchParams;
+      end_date_lookup?: DateLookupSearchParams;
 
       end_date_year?: string;
-      end_date_year__lookup?: DateLookupSearchParams;
+      end_date_year_lookup?: DateLookupSearchParams;
 
       /** Places (AND query). */
       ort?: Array<Place['id']>;
 
       kommentar?: string;
-      kommentar__lookup?: StringLookupSearchParams;
+      kommentar_lookup?: StringLookupSearchParams;
 
       /** Keywords for texts by these authors (AND query). */
       rvn_text_autor_autor__rvn_stelle_text_text__key_word?: Array<Keyword['id']>;
@@ -410,16 +411,16 @@ export namespace GetKeywords {
       art?: KeywordType;
 
       stichwort?: string;
-      stichwort__lookup?: StringLookupSearchParams;
+      stichwort_lookup?: StringLookupSearchParams;
 
       wurzel?: string;
-      wurzel__lookup?: StringLookupSearchParams;
+      wurzel_lookup?: StringLookupSearchParams;
 
       kommentar?: string;
-      kommentar__lookup?: StringLookupSearchParams;
+      kommentar_lookup?: StringLookupSearchParams;
 
       varianten?: string;
-      varianten__lookup?: StringLookupSearchParams;
+      varianten_lookup?: StringLookupSearchParams;
 
       /** Keywords used by these authors (AND query). */
       rvn_stelle_key_word_keyword__text__autor?: Array<Author['id']>;
@@ -442,22 +443,22 @@ export namespace GetKeywords {
       rvn_stelle_key_word_keyword__text__autor__ort?: Array<Place['id']>;
 
       rvn_stelle_key_word_keyword__text__autor__start_date_year?: string;
-      rvn_stelle_key_word_keyword__text__autor__start_date_year__lookup?: DateLookupSearchParams;
+      rvn_stelle_key_word_keyword__text__autor__start_date_year_lookup?: DateLookupSearchParams;
 
       rvn_stelle_key_word_keyword__text__autor__end_date_year?: string;
-      rvn_stelle_key_word_keyword__text__autor__end_date_year__lookup?: DateLookupSearchParams;
+      rvn_stelle_key_word_keyword__text__autor__end_date_year_lookup?: DateLookupSearchParams;
 
       rvn_stelle_key_word_keyword__text__not_before?: string;
-      rvn_stelle_key_word_keyword__text__not_before__lookup?: DateLookupSearchParams;
+      rvn_stelle_key_word_keyword__text__not_before_lookup?: DateLookupSearchParams;
 
       rvn_stelle_key_word_keyword__text__not_after?: string;
-      rvn_stelle_key_word_keyword__text__not_after__lookup?: DateLookupSearchParams;
+      rvn_stelle_key_word_keyword__text__not_after_lookup?: DateLookupSearchParams;
 
       rvn_stelle_key_word_keyword__start_date?: string;
-      rvn_stelle_key_word_keyword__start_date__lookup?: DateLookupSearchParams;
+      rvn_stelle_key_word_keyword__start_date_lookup?: DateLookupSearchParams;
 
       rvn_stelle_key_word_keyword__end_date?: string;
-      rvn_stelle_key_word_keyword__end_date__lookup?: DateLookupSearchParams;
+      rvn_stelle_key_word_keyword__end_date_lookup?: DateLookupSearchParams;
 
       /** Keywords are associated with these usecases (AND query). */
       rvn_stelle_key_word_keyword__use_case?: Array<UseCase['id']>;
@@ -491,22 +492,22 @@ export namespace GetPlaces {
       /** Comma-separated list of IDs. */
       ids?: string;
       norm_id?: string;
-      norm_id__lookup?: StringLookupSearchParams;
+      norm_id_lookup?: StringLookupSearchParams;
 
       name?: string;
-      name__lookup?: StringLookupSearchParams;
+      name_lookup?: StringLookupSearchParams;
 
       name_antik?: string;
-      name_antik__lookup?: StringLookupSearchParams;
+      name_antik_lookup?: StringLookupSearchParams;
 
       name_de?: string;
-      name_de__lookup?: StringLookupSearchParams;
+      name_de_lookup?: StringLookupSearchParams;
 
       name_fr?: string;
-      name_fr__lookup?: StringLookupSearchParams;
+      name_fr_lookup?: StringLookupSearchParams;
 
       name_it?: string;
-      name_it__lookup?: StringLookupSearchParams;
+      name_it_lookup?: StringLookupSearchParams;
 
       /**
        * Place types (AND query).
@@ -525,7 +526,7 @@ export namespace GetPlaces {
       kategorie?: Array<SkosConcept['id']>;
 
       kommentar?: string;
-      kommentar__lookup?: StringLookupSearchParams;
+      kommentar_lookup?: StringLookupSearchParams;
 
       /** Related authors (AND query). */
       rvn_autor_ort_ort?: Array<Author['id']>;
@@ -609,13 +610,13 @@ export namespace GetPassages {
       ort?: Array<Place['id']>;
 
       summary?: string;
-      summary__lookup?: StringLookupSearchParams;
+      summary_lookup?: StringLookupSearchParams;
 
       zitat?: string;
-      zitat__lookup?: StringLookupSearchParams;
+      zitat_lookup?: StringLookupSearchParams;
 
       translation?: string;
-      translation__lookup?: StringLookupSearchParams;
+      translation_lookup?: StringLookupSearchParams;
 
       /** Keyword type. */
       key_word__art?: KeywordType;
@@ -630,25 +631,25 @@ export namespace GetPassages {
       key_word?: Array<Keyword['id']>;
 
       kommentar?: string;
-      kommentar__lookup?: StringLookupSearchParams;
+      kommentar_lookup?: StringLookupSearchParams;
 
       start_date?: number;
-      start_date__lookup?: DateLookupSearchParams;
+      start_date_lookup?: DateLookupSearchParams;
 
       end_date?: number;
-      end_date__lookup?: DateLookupSearchParams;
+      end_date_lookup?: DateLookupSearchParams;
 
       text__start_date?: string;
-      text__start_date__lookup?: DateLookupSearchParams;
+      text__start_date_lookup?: DateLookupSearchParams;
 
       text__end_date?: string;
-      text__end_date__lookup?: DateLookupSearchParams;
+      text__end_date_lookup?: DateLookupSearchParams;
 
       text__autor__start_date_year?: string;
-      text__autor__start_date_year__lookup?: DateLookupSearchParams;
+      text__autor__start_date_year_lookup?: DateLookupSearchParams;
 
       text__autor__end_date_year?: string;
-      text__autor__end_date_year__lookup?: DateLookupSearchParams;
+      text__autor__end_date_year_lookup?: DateLookupSearchParams;
     };
   export type Response = PaginatedResponse<
     Omit<Passage, 'key_word' | 'ort' | 'use_case'> & {
@@ -758,25 +759,25 @@ export namespace GetTexts {
       autor?: Array<Author['id']>;
 
       autor__start_date_year?: string;
-      autor__start_date_year__lookup?: DateLookupSearchParams;
+      autor__start_date_year_lookup?: DateLookupSearchParams;
 
       autor__end_date_year?: string;
-      autor__end_date_year__lookup?: DateLookupSearchParams;
+      autor__end_date_year_lookup?: DateLookupSearchParams;
 
       title?: string;
-      title__lookup?: StringLookupSearchParams;
+      title_lookup?: StringLookupSearchParams;
 
       jahrhundert?: string;
-      jahrhundert__lookup?: StringLookupSearchParams;
+      jahrhundert_lookup?: StringLookupSearchParams;
 
       not_before?: number;
-      not_before__lookup?: DateLookupSearchParams;
+      not_before_lookup?: DateLookupSearchParams;
 
       not_after?: number;
-      not_after__lookup?: DateLookupSearchParams;
+      not_after_lookup?: DateLookupSearchParams;
 
       edition?: string;
-      edition__lookup?: StringLookupSearchParams;
+      edition_lookup?: StringLookupSearchParams;
 
       /**
        * Genres (AND query).
@@ -790,7 +791,7 @@ export namespace GetTexts {
       ort?: Array<Place['id']>;
 
       kommentar?: string;
-      kommentar__lookup?: StringLookupSearchParams;
+      kommentar_lookup?: StringLookupSearchParams;
 
       /** Keywords (AND query). */
       rvn_stelle_text_text__key_word?: Array<Keyword['id']>;
@@ -844,7 +845,7 @@ export function getTextById(params: GetTextById.PathParams): Promise<GetTextById
   return request(url, options);
 }
 
-export namespace GetUseCases {
+export namespace GetCaseStudies {
   export type SearchParams = LimitOffsetPaginationSearchParams &
     SortableSearchParams & {
       id?: UseCase['id'];
@@ -852,16 +853,16 @@ export namespace GetUseCases {
       ids?: string;
 
       title?: string;
-      title__lookup?: StringLookupSearchParams;
+      title_lookup?: StringLookupSearchParams;
 
       principal_investigator?: string;
-      principal_investigator__lookup?: StringLookupSearchParams;
+      principal_investigator_lookup?: StringLookupSearchParams;
 
       pi_norm_id?: string;
-      pi_norm_id__lookup?: StringLookupSearchParams;
+      pi_norm_id_lookup?: StringLookupSearchParams;
 
       description?: string;
-      description__lookup?: StringLookupSearchParams;
+      description_lookup?: StringLookupSearchParams;
 
       /** Related texts (AND query). */
       has_stelle__text?: Array<Text['id']>;
@@ -894,12 +895,14 @@ export namespace GetUseCases {
   >;
 }
 
-export function getUseCases(searchParams: GetUseCases.SearchParams): Promise<GetUseCases.Response> {
+export function getCaseStudies(
+  searchParams: GetCaseStudies.SearchParams
+): Promise<GetCaseStudies.Response> {
   const url = createUrl({ baseUrl: baseUrls.api, pathname: 'usecase/', searchParams });
   return request(url, options);
 }
 
-export namespace GetUseCaseById {
+export namespace GetCaseStudyById {
   export type PathParams = {
     id: UseCase['id'];
   };
@@ -908,9 +911,9 @@ export namespace GetUseCaseById {
   };
 }
 
-export function getUseCaseById(
-  params: GetUseCaseById.PathParams
-): Promise<GetUseCaseById.Response> {
+export function getCaseStudyById(
+  params: GetCaseStudyById.PathParams
+): Promise<GetCaseStudyById.Response> {
   const url = createUrl({ baseUrl: baseUrls.api, pathname: `usecase/${params.id}` });
   return request(url, options);
 }
@@ -947,16 +950,16 @@ export namespace GetEvents {
   export type SearchParams = LimitOffsetPaginationSearchParams &
     SortableSearchParams & {
       title?: string;
-      title__lookup?: StringLookupSearchParams;
+      title_lookup?: StringLookupSearchParams;
 
       description?: string;
-      description__lookup?: StringLookupSearchParams;
+      description_lookup?: StringLookupSearchParams;
 
       start_date?: number;
-      start_date__lookup?: DateLookupSearchParams;
+      start_date_lookup?: DateLookupSearchParams;
 
       end_date?: number;
-      end_date__lookup?: DateLookupSearchParams;
+      end_date_lookup?: DateLookupSearchParams;
 
       use_case?: Array<UseCase['id']>;
     };
@@ -1176,22 +1179,22 @@ export type SpatialCoverageSearchParams = {
   stelle__text__art?: Array<SkosConcept['id']>;
 
   stelle__start_date?: number;
-  stelle__start_date__lookup?: DateLookupSearchParams;
+  stelle__start_date_lookup?: DateLookupSearchParams;
 
   stelle__end_date?: number;
-  stelle__end_date__lookup?: DateLookupSearchParams;
+  stelle__end_date_lookup?: DateLookupSearchParams;
 
   stelle__text__not_before?: number;
-  stelle__text__not_before__lookup?: DateLookupSearchParams;
+  stelle__text__not_before_lookup?: DateLookupSearchParams;
 
   stelle__text__not_after?: number;
-  stelle__text__not_after__lookup?: DateLookupSearchParams;
+  stelle__text__not_after_lookup?: DateLookupSearchParams;
 
   stelle__text__autor__start_date_year?: number;
-  stelle__text__autor__start_date_year__lookup?: DateLookupSearchParams;
+  stelle__text__autor__start_date_year_lookup?: DateLookupSearchParams;
 
   stelle__text__autor__end_date_year?: number;
-  stelle__text__autor__end_date_year__lookup?: DateLookupSearchParams;
+  stelle__text__autor__end_date_year_lookup?: DateLookupSearchParams;
 };
 
 export type ConeGeojson = { id: SpatialCoverage['id'] } & Feature<
@@ -1434,7 +1437,7 @@ export function getSkosConceptSchemeById(
 
 //
 
-export namespace GetUseCaseTimetableById {
+export namespace GetCaseStudyTimetableById {
   export type PathParams = {
     id: UseCase['id'];
   };
@@ -1442,7 +1445,7 @@ export namespace GetUseCaseTimetableById {
     id: UseCase['id'];
     start_date: number;
     end_date: number;
-    ent_type: 'event';
+    ent_type: 'autor' | 'event' | 'text';
     ent_title: string;
     ent_description: string;
     /** Pathname only */
@@ -1450,9 +1453,9 @@ export namespace GetUseCaseTimetableById {
   }>;
 }
 
-export function getUseCaseTimetableById(
-  params: GetUseCaseTimetableById.PathParams
-): Promise<GetUseCaseTimetableById.Response> {
+export function getCaseStudyTimetableById(
+  params: GetCaseStudyTimetableById.PathParams
+): Promise<GetCaseStudyTimetableById.Response> {
   const url = createUrl({
     baseUrl: baseUrls.archiv,
     pathname: `usecase-timetable-data/${params.id}`,

--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -1,5 +1,3 @@
-/* eslint @typescript-eslint/no-unused-vars: ["error", { "argsIgnorePattern": "^_" }] */
-
 import { assert } from '@stefanprobst/assert';
 import type { UseQueryOptions } from '@tanstack/vue-query';
 import { useQuery } from '@tanstack/vue-query';
@@ -8,6 +6,16 @@ import type { Ref } from 'vue';
 import * as api from '@/api/client';
 
 type MaybeRef<T> = T | Ref<T>;
+
+// FIXME: currently, `vue-query` correctly deeply unwraps the `queryKey` passed to the `queryFn`,
+// but the types don't properly flow through.
+type MaybeRefDeep<T> = MaybeRef<
+  T extends Array<unknown> | Record<string, unknown>
+    ? {
+        [K in keyof T]: MaybeRefDeep<T[K]>;
+      }
+    : T
+>;
 
 type Options = {
   isEnabled?: UseQueryOptions['enabled'];
@@ -34,6 +42,7 @@ const resources = [
   'author',
   'autocomplete',
   'autocomplete-author',
+  'autocomplete-case-study',
   'autocomplete-keyword',
   'autocomplete-keyword-region',
   'autocomplete-keyword-ethnonym',
@@ -42,10 +51,10 @@ const resources = [
   'autocomplete-place',
   'autocomplete-passage',
   'autocomplete-text',
-  'autocomplete-usecase',
   'autocomplete-text-genre-type',
   'autocomplete-place-type',
   'autocomplete-place-category',
+  'case-study',
   'event',
   'geojson-layer',
   'geojson-place',
@@ -67,12 +76,11 @@ const resources = [
   'text',
   'text-topic-relation',
   'topic',
-  'use-case',
 ] as const;
 
 const scopes = ['list', 'by-id'] as const;
 
-function createKey<
+export function createKey<
   TResource extends typeof resources[number],
   TScope extends typeof scopes[number],
   TArgs extends Array<MaybeRef<unknown>>
@@ -88,12 +96,13 @@ function assertParams<T extends object, K extends keyof T>(params: T, keys: Arra
 }
 
 export function useAuthors(
-  searchParams: MaybeRef<Partial<api.GetAuthors.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetAuthors.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('author', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getAuthors(searchParams);
     },
     ...getQueryOptions(options),
@@ -101,12 +110,13 @@ export function useAuthors(
 }
 
 export function useAuthorById(
-  params: MaybeRef<Partial<api.GetAuthorById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetAuthorById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('author', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getAuthorById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -114,12 +124,13 @@ export function useAuthorById(
 }
 
 export function useKeywords(
-  searchParams: MaybeRef<Partial<api.GetKeywords.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetKeywords.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('keyword', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getKeywords(searchParams);
     },
     ...getQueryOptions(options),
@@ -127,12 +138,13 @@ export function useKeywords(
 }
 
 export function useKeywordById(
-  params: MaybeRef<Partial<api.GetKeywordById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetKeywordById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('keyword', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getKeywordById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -140,12 +152,13 @@ export function useKeywordById(
 }
 
 export function useKeywordByCenturyById(
-  params: MaybeRef<Partial<api.GetKeywordById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetKeywordById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('keyword', 'by-id', params, 'century'),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getKeywordByCenturyById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -153,12 +166,13 @@ export function useKeywordByCenturyById(
 }
 
 export function useKeywordGraph(
-  searchParams: MaybeRef<Partial<api.GetKeywordGraph.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetKeywordGraph.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('keyword', 'list', searchParams, 'graph'),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getKeywordGraph(searchParams);
     },
     ...getQueryOptions(options),
@@ -166,12 +180,13 @@ export function useKeywordGraph(
 }
 
 export function usePassages(
-  searchParams: MaybeRef<Partial<api.GetPassages.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetPassages.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('passage', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getPassages(searchParams);
     },
     ...getQueryOptions(options),
@@ -179,12 +194,13 @@ export function usePassages(
 }
 
 export function usePassageById(
-  params: MaybeRef<Partial<api.GetPassageById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetPassageById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('passage', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getPassageById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -192,12 +208,13 @@ export function usePassageById(
 }
 
 export function usePassageKeywords(
-  searchParams: MaybeRef<Partial<api.GetPassageKeywords.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetPassageKeywords.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('passage', 'list', searchParams, 'keywords'),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getPassageKeywords(searchParams);
     },
     ...getQueryOptions(options),
@@ -205,12 +222,13 @@ export function usePassageKeywords(
 }
 
 export function usePassageNlpData(
-  searchParams: MaybeRef<Partial<api.GetPassageNlpData.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetPassageNlpData.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('passage', 'list', searchParams, 'nlp-data'),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getPassageNlpData(searchParams);
     },
     ...getQueryOptions(options),
@@ -218,12 +236,13 @@ export function usePassageNlpData(
 }
 
 export function usePlaces(
-  searchParams: MaybeRef<Partial<api.GetPlaces.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetPlaces.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('place', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getPlaces(searchParams);
     },
     ...getQueryOptions(options),
@@ -231,12 +250,13 @@ export function usePlaces(
 }
 
 export function usePlaceById(
-  params: MaybeRef<Partial<api.GetPlaceById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetPlaceById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('place', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getPlaceById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -244,12 +264,13 @@ export function usePlaceById(
 }
 
 export function useTexts(
-  searchParams: MaybeRef<Partial<api.GetTexts.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetTexts.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('text', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getTexts(searchParams);
     },
     ...getQueryOptions(options),
@@ -257,64 +278,69 @@ export function useTexts(
 }
 
 export function useTextById(
-  params: MaybeRef<Partial<api.GetTextById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetTextById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('text', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getTextById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
 }
 
-export function useUseCases(
-  searchParams: MaybeRef<Partial<api.GetUseCases.SearchParams>>,
+export function useCaseStudies(
+  searchParams: MaybeRefDeep<Partial<api.GetCaseStudies.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
-    queryKey: createKey('use-case', 'list', searchParams),
+    queryKey: createKey('case-study', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
-      return api.getUseCases(searchParams);
+      // @ts-expect-error Upstream type error.
+      return api.getCaseStudies(searchParams);
     },
     ...getQueryOptions(options),
   });
 }
 
-export function useUseCaseById(
-  params: MaybeRef<Partial<api.GetUseCaseById.PathParams>>,
+export function useCaseStudyById(
+  params: MaybeRefDeep<Partial<api.GetCaseStudyById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
-    queryKey: createKey('use-case', 'by-id', params),
+    queryKey: createKey('case-study', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getUseCaseById(assertParams(params, ['id']));
+      // @ts-expect-error Upstream type error.
+      return api.getCaseStudyById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
 }
 
-export function useUseCaseTimeTableById(
-  params: MaybeRef<Partial<api.GetSkosConceptSchemeById.PathParams>>,
+export function useCaseStudyTimeTableById(
+  params: MaybeRefDeep<Partial<api.GetCaseStudyTimetableById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
-    queryKey: createKey('use-case', 'by-id', params, 'timetable'),
+    queryKey: createKey('case-study', 'by-id', params, 'timetable'),
     queryFn: ({ queryKey: [, , params] }) => {
-      return api.getUseCaseTimetableById(assertParams(params, ['id']));
+      // @ts-expect-error Upstream type error.
+      return api.getCaseStudyTimetableById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
   });
 }
 
 export function useGeojsonLayers(
-  searchParams: MaybeRef<Partial<api.GetGeojsonLayers.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetGeojsonLayers.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('geojson-layer', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getGeojsonLayers(searchParams);
     },
     ...getQueryOptions(options),
@@ -322,12 +348,13 @@ export function useGeojsonLayers(
 }
 
 export function useGeojsonLayerById(
-  params: MaybeRef<Partial<api.GetGeojsonLayerById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetGeojsonLayerById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('geojson-layer', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getGeojsonLayerById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -335,12 +362,13 @@ export function useGeojsonLayerById(
 }
 
 export function useEvents(
-  searchParams: MaybeRef<Partial<api.GetEvents.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetEvents.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('event', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getEvents(searchParams);
     },
     ...getQueryOptions(options),
@@ -348,12 +376,13 @@ export function useEvents(
 }
 
 export function useEventById(
-  params: MaybeRef<Partial<api.GetEventById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetEventById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('event', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getEventById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -361,12 +390,13 @@ export function useEventById(
 }
 
 export function useModelingProcesses(
-  searchParams: MaybeRef<Partial<api.GetModelingProcesses.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetModelingProcesses.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('modeling-process', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getModelingProcesses(searchParams);
     },
     ...getQueryOptions(options),
@@ -374,12 +404,13 @@ export function useModelingProcesses(
 }
 
 export function useModelingProcessById(
-  params: MaybeRef<Partial<api.GetModelingProcessById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetModelingProcessById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('modeling-process', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getModelingProcessById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -387,12 +418,13 @@ export function useModelingProcessById(
 }
 
 export function useStopWords(
-  searchParams: MaybeRef<Partial<api.GetStopWords.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetStopWords.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('stop-word', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getStopWords(searchParams);
     },
     ...getQueryOptions(options),
@@ -400,12 +432,13 @@ export function useStopWords(
 }
 
 export function useTextTopicRelations(
-  searchParams: MaybeRef<Partial<api.GetTextTopicRelations.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetTextTopicRelations.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('text-topic-relation', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getTextTopicRelations(searchParams);
     },
     ...getQueryOptions(options),
@@ -413,12 +446,13 @@ export function useTextTopicRelations(
 }
 
 export function useTextTopicRelationById(
-  params: MaybeRef<Partial<api.GetTextTopicRelationById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetTextTopicRelationById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('text-topic-relation', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getTextTopicRelationById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -426,12 +460,13 @@ export function useTextTopicRelationById(
 }
 
 export function useTopics(
-  searchParams: MaybeRef<Partial<api.GetTopics.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetTopics.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('topic', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getTopics(searchParams);
     },
     ...getQueryOptions(options),
@@ -439,12 +474,13 @@ export function useTopics(
 }
 
 export function useTopicById(
-  params: MaybeRef<Partial<api.GetTopicById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetTopicById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('topic', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getTopicById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -452,12 +488,13 @@ export function useTopicById(
 }
 
 export function usePlacesGeojson(
-  searchParams: MaybeRef<Partial<api.GetPlacesGeojson.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetPlacesGeojson.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('geojson-place', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getPlacesGeojson(searchParams);
     },
     ...getQueryOptions(options),
@@ -465,12 +502,13 @@ export function usePlacesGeojson(
 }
 
 export function usePlaceGeojsonById(
-  params: MaybeRef<Partial<api.GetPlaceGeojsonById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetPlaceGeojsonById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('geojson-place', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getPlaceGeojsonById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -478,12 +516,13 @@ export function usePlaceGeojsonById(
 }
 
 export function useFuzzyPlacesGeojson(
-  searchParams: MaybeRef<Partial<api.GetFuzzyPlacesGeojson.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetFuzzyPlacesGeojson.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('geojson-fuzzy-place', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getFuzzyPlacesGeojson(searchParams);
     },
     ...getQueryOptions(options),
@@ -491,12 +530,13 @@ export function useFuzzyPlacesGeojson(
 }
 
 export function useFuzzyPlaceGeojsonById(
-  params: MaybeRef<Partial<api.GetFuzzyPlaceGeojsonById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetFuzzyPlaceGeojsonById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('geojson-fuzzy-place', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getFuzzyPlaceGeojsonById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -504,12 +544,13 @@ export function useFuzzyPlaceGeojsonById(
 }
 
 export function useConesGeojson(
-  searchParams: MaybeRef<Partial<api.GetConesGeojson.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetConesGeojson.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('geojson-cone', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getConesGeojson(searchParams);
     },
     ...getQueryOptions(options),
@@ -517,12 +558,13 @@ export function useConesGeojson(
 }
 
 export function useConeGeojsonById(
-  params: MaybeRef<Partial<api.GetConeGeojsonById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetConeGeojsonById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('geojson-cone', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getConeGeojsonById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -530,12 +572,13 @@ export function useConeGeojsonById(
 }
 
 export function useSpatialCoveragesGeojson(
-  searchParams: MaybeRef<Partial<api.GetSpatialCoveragesGeojson.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetSpatialCoveragesGeojson.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('geojson-spatial-coverage', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getSpatialCoveragesGeojson(searchParams);
     },
     ...getQueryOptions(options),
@@ -543,12 +586,13 @@ export function useSpatialCoveragesGeojson(
 }
 
 export function useSpatialCoverageGeojsonById(
-  params: MaybeRef<Partial<api.GetSpatialCoverageGeojsonById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetSpatialCoverageGeojsonById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('geojson-spatial-coverage', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getSpatialCoverageGeojsonById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -556,12 +600,13 @@ export function useSpatialCoverageGeojsonById(
 }
 
 export function useLinesPointsGeojson(
-  searchParams: MaybeRef<Partial<api.GetLinesPointsGeojson.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetLinesPointsGeojson.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('geojson-lines-points', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getLinesPointsGeojson(searchParams);
     },
     ...getQueryOptions(options),
@@ -569,12 +614,13 @@ export function useLinesPointsGeojson(
 }
 
 export function useLinesPointsGeojsonById(
-  params: MaybeRef<Partial<api.GetLinesPointsGeojsonById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetLinesPointsGeojsonById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('geojson-lines-points', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getLinesPointsGeojsonById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -582,12 +628,13 @@ export function useLinesPointsGeojsonById(
 }
 
 export function useStories(
-  searchParams: MaybeRef<Partial<api.GetStories.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetStories.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('story', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getStories(searchParams);
     },
     ...getQueryOptions(options),
@@ -595,12 +642,13 @@ export function useStories(
 }
 
 export function useStoryById(
-  params: MaybeRef<Partial<api.GetStoryById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetStoryById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('story', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getStoryById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -608,12 +656,13 @@ export function useStoryById(
 }
 
 export function useStorySlides(
-  searchParams: MaybeRef<Partial<api.GetStorySlides.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetStorySlides.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('story-slide', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getStorySlides(searchParams);
     },
     ...getQueryOptions(options),
@@ -621,12 +670,13 @@ export function useStorySlides(
 }
 
 export function useStorySlideById(
-  params: MaybeRef<Partial<api.GetStorySlideById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetStorySlideById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('story-slide', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getStorySlideById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -634,12 +684,13 @@ export function useStorySlideById(
 }
 
 export function useSkosCollections(
-  searchParams: MaybeRef<Partial<api.GetSkosCollections.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetSkosCollections.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('skos-collection', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getSkosCollections(searchParams);
     },
     ...getQueryOptions(options),
@@ -647,12 +698,13 @@ export function useSkosCollections(
 }
 
 export function useSkosCollectionById(
-  params: MaybeRef<Partial<api.GetSkosCollectionById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetSkosCollectionById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('skos-collection', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getSkosCollectionById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -660,12 +712,13 @@ export function useSkosCollectionById(
 }
 
 export function useSkosConcepts(
-  searchParams: MaybeRef<Partial<api.GetSkosConcepts.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetSkosConcepts.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('skos-concept', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getSkosConcepts(searchParams);
     },
     ...getQueryOptions(options),
@@ -673,12 +726,13 @@ export function useSkosConcepts(
 }
 
 export function useSkosConceptById(
-  params: MaybeRef<Partial<api.GetSkosConceptById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetSkosConceptById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('skos-concept', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getSkosConceptById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -686,12 +740,13 @@ export function useSkosConceptById(
 }
 
 export function useSkosConceptSchemes(
-  searchParams: MaybeRef<Partial<api.GetSkosConceptSchemes.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetSkosConceptSchemes.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('skos-concept-scheme', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getSkosConceptSchemes(searchParams);
     },
     ...getQueryOptions(options),
@@ -699,12 +754,13 @@ export function useSkosConceptSchemes(
 }
 
 export function useSkosConceptSchemeById(
-  params: MaybeRef<Partial<api.GetSkosConceptSchemeById.PathParams>>,
+  params: MaybeRefDeep<Partial<api.GetSkosConceptSchemeById.PathParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('skos-concept-scheme', 'by-id', params),
     queryFn: ({ queryKey: [, , params] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getSkosConceptSchemeById(assertParams(params, ['id']));
     },
     ...getQueryOptions(options),
@@ -712,12 +768,13 @@ export function useSkosConceptSchemeById(
 }
 
 export function useAuthorsAutoComplete(
-  searchParams: MaybeRef<Partial<api.GetAuthorsAutoComplete.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetAuthorsAutoComplete.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('autocomplete-author', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getAuthorsAutoComplete(searchParams);
     },
     ...getQueryOptions(options),
@@ -725,12 +782,13 @@ export function useAuthorsAutoComplete(
 }
 
 export function useKeywordsAutoComplete(
-  searchParams: MaybeRef<Partial<api.GetKeywordsAutoComplete.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetKeywordsAutoComplete.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('autocomplete-keyword', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getKeywordsAutoComplete(searchParams);
     },
     ...getQueryOptions(options),
@@ -738,12 +796,13 @@ export function useKeywordsAutoComplete(
 }
 
 export function useRegionKeywordsAutoComplete(
-  searchParams: MaybeRef<Partial<api.GetRegionKeywordsAutoComplete.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetRegionKeywordsAutoComplete.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('autocomplete-keyword-region', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getRegionKeywordsAutoComplete(searchParams);
     },
     ...getQueryOptions(options),
@@ -751,12 +810,13 @@ export function useRegionKeywordsAutoComplete(
 }
 
 export function useEthnonymKeywordsAutoComplete(
-  searchParams: MaybeRef<Partial<api.GetEthnonymKeywordsAutoComplete.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetEthnonymKeywordsAutoComplete.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('autocomplete-keyword-ethnonym', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getEthnonymKeywordsAutoComplete(searchParams);
     },
     ...getQueryOptions(options),
@@ -764,12 +824,13 @@ export function useEthnonymKeywordsAutoComplete(
 }
 
 export function useKeywordKeywordsAutoComplete(
-  searchParams: MaybeRef<Partial<api.GetKeywordKeywordsAutoComplete.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetKeywordKeywordsAutoComplete.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('autocomplete-keyword-keyword', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getKeywordKeywordsAutoComplete(searchParams);
     },
     ...getQueryOptions(options),
@@ -777,12 +838,13 @@ export function useKeywordKeywordsAutoComplete(
 }
 
 export function useNameKeywordsAutoComplete(
-  searchParams: MaybeRef<Partial<api.GetNameKeywordsAutoComplete.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetNameKeywordsAutoComplete.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('autocomplete-keyword-name', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getNameKeywordsAutoComplete(searchParams);
     },
     ...getQueryOptions(options),
@@ -790,12 +852,13 @@ export function useNameKeywordsAutoComplete(
 }
 
 export function usePlacesAutoComplete(
-  searchParams: MaybeRef<Partial<api.GetPlacesAutoComplete.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetPlacesAutoComplete.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('autocomplete-place', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getPlacesAutoComplete(searchParams);
     },
     ...getQueryOptions(options),
@@ -803,12 +866,13 @@ export function usePlacesAutoComplete(
 }
 
 export function usePassagesAutoComplete(
-  searchParams: MaybeRef<Partial<api.GetPassagesAutoComplete.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetPassagesAutoComplete.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('autocomplete-passage', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getPassagesAutoComplete(searchParams);
     },
     ...getQueryOptions(options),
@@ -816,38 +880,41 @@ export function usePassagesAutoComplete(
 }
 
 export function useTextsAutoComplete(
-  searchParams: MaybeRef<Partial<api.GetTextsAutoComplete.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetTextsAutoComplete.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('autocomplete-text', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getTextsAutoComplete(searchParams);
     },
     ...getQueryOptions(options),
   });
 }
 
-export function useUseCasesAutoComplete(
-  searchParams: MaybeRef<Partial<api.GetUseCasesAutoComplete.SearchParams>>,
+export function useCaseStudiesAutoComplete(
+  searchParams: MaybeRefDeep<Partial<api.GetCaseStudiesAutoComplete.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
-    queryKey: createKey('autocomplete-usecase', 'list', searchParams),
+    queryKey: createKey('autocomplete-case-study', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
-      return api.getUseCasesAutoComplete(searchParams);
+      // @ts-expect-error Upstream type error.
+      return api.getCaseStudiesAutoComplete(searchParams);
     },
     ...getQueryOptions(options),
   });
 }
 
 export function useTextGenreTypesAutoComplete(
-  searchParams: MaybeRef<Partial<api.GetTextGenreTypesAutoComplete.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetTextGenreTypesAutoComplete.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('autocomplete-text-genre-type', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getTextGenreTypesAutoComplete(searchParams);
     },
     ...getQueryOptions(options),
@@ -855,12 +922,13 @@ export function useTextGenreTypesAutoComplete(
 }
 
 export function usePlaceTypesAutoComplete(
-  searchParams: MaybeRef<Partial<api.GetPlaceTypesAutoComplete.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetPlaceTypesAutoComplete.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('autocomplete-place-type', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getPlaceTypesAutoComplete(searchParams);
     },
     ...getQueryOptions(options),
@@ -868,12 +936,13 @@ export function usePlaceTypesAutoComplete(
 }
 
 export function usePlaceCategoriesAutoComplete(
-  searchParams: MaybeRef<Partial<api.GetPlaceCategoriesAutoComplete.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetPlaceCategoriesAutoComplete.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('autocomplete-place-category', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getPlaceCategoriesAutoComplete(searchParams);
     },
     ...getQueryOptions(options),
@@ -881,12 +950,13 @@ export function usePlaceCategoriesAutoComplete(
 }
 
 export function useAutoComplete(
-  searchParams: MaybeRef<Partial<api.GetAutoComplete.SearchParams>>,
+  searchParams: MaybeRefDeep<Partial<api.GetAutoComplete.SearchParams>>,
   options?: Options
 ) {
   return useQuery({
     queryKey: createKey('autocomplete', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
+      // @ts-expect-error Upstream type error.
       return api.getAutoComplete(assertParams(searchParams, ['q']));
     },
     ...getQueryOptions(options),


### PR DESCRIPTION
fix api client to use `_lookup` prefix instead  of `__lookup`, change `usecase` to `casestudy` where appropriate (i.e. not in search params, but in function and type names).