### PR TITLE
refactor: use api client for data fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@fontsource/roboto-flex": "^4.5.2",
         "@mdi/font": "^7.0.96",
         "@stefanprobst/assert": "^1.0.3",
+        "@stefanprobst/group-by": "^1.1.0",
         "@stefanprobst/request": "^0.2.1",
         "@tanstack/vue-query": "^4.14.3",
         "@turf/turf": "^6.5.0",
@@ -392,6 +393,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@stefanprobst/assert/-/assert-1.0.3.tgz",
       "integrity": "sha512-3FkU7sHtfCpgO3+YqNWDRc3b220LO/ZtdxUtiVhP0+2xqZ+E9LNe3hXaiFeVCeSUmi3y8V333L4+x6ME2vzpHg=="
+    },
+    "node_modules/@stefanprobst/group-by": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@stefanprobst/group-by/-/group-by-1.1.0.tgz",
+      "integrity": "sha512-VX3x210KaLS+4h1PGUkm4iYUr5w+6kdfR8kKh+9qwx9s8Lu47RYsgvytc98b1ONPIRQ3RJe96qLqVymUzISA8A=="
     },
     "node_modules/@stefanprobst/request": {
       "version": "0.2.1",
@@ -9854,6 +9860,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@stefanprobst/assert/-/assert-1.0.3.tgz",
       "integrity": "sha512-3FkU7sHtfCpgO3+YqNWDRc3b220LO/ZtdxUtiVhP0+2xqZ+E9LNe3hXaiFeVCeSUmi3y8V333L4+x6ME2vzpHg=="
+    },
+    "@stefanprobst/group-by": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@stefanprobst/group-by/-/group-by-1.1.0.tgz",
+      "integrity": "sha512-VX3x210KaLS+4h1PGUkm4iYUr5w+6kdfR8kKh+9qwx9s8Lu47RYsgvytc98b1ONPIRQ3RJe96qLqVymUzISA8A=="
     },
     "@stefanprobst/request": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@fontsource/roboto-flex": "^4.5.2",
     "@mdi/font": "^7.0.96",
     "@stefanprobst/assert": "^1.0.3",
+    "@stefanprobst/group-by": "^1.1.0",
     "@stefanprobst/request": "^0.2.1",
     "@tanstack/vue-query": "^4.14.3",
     "@turf/turf": "^6.5.0",

--- a/src/components/AppBar.vue
+++ b/src/components/AppBar.vue
@@ -37,7 +37,7 @@
             <span class="non-selectable" :class="{ 'white--text': isHome }">
               &nbsp;&nbsp;&bull;&nbsp;&nbsp;
             </span>
-            <router-link :to="{ name: 'Studies', query: $route.query }" class="nav-link">
+            <router-link :to="{ name: 'Case Studies', query: $route.query }" class="nav-link">
               Case&nbsp;Studies
             </router-link>
             <span class="non-selectable" :class="{ 'white--text': isHome }">

--- a/src/components/AppBar.vue
+++ b/src/components/AppBar.vue
@@ -17,7 +17,7 @@
           />
           <v-toolbar-title class="d-inline fancy-font font-weight-bold text-decoration-none">
             <router-link
-              :to="{ name: 'Home', query: addParamsToQuery() }"
+              :to="{ name: 'Home', query: $route.query }"
               class="nav-link"
               :class="{ light: !isHome }"
             >
@@ -29,7 +29,7 @@
           <div :class="{ light: !isHome }">
             <router-link
               color="white"
-              :to="{ name: '', params: {}, query: addParamsToQuery() }"
+              :to="{ name: '', params: {}, query: $route.query }"
               class="nav-link"
             >
               About the Project
@@ -37,14 +37,14 @@
             <span class="non-selectable" :class="{ 'white--text': isHome }">
               &nbsp;&nbsp;&bull;&nbsp;&nbsp;
             </span>
-            <router-link :to="{ name: 'Studies', query: addParamsToQuery() }" class="nav-link">
+            <router-link :to="{ name: 'Studies', query: $route.query }" class="nav-link">
               Case&nbsp;Studies
             </router-link>
             <span class="non-selectable" :class="{ 'white--text': isHome }">
               &nbsp;&nbsp;&bull;&nbsp;&nbsp;
             </span>
             <router-link
-              :to="{ name: $store.state.interface.currentView, query: addParamsToQuery() }"
+              :to="{ name: $store.state.interface.currentView, query: $route.query }"
               class="nav-link"
             >
               Explore&nbsp;the&nbsp;Data

--- a/src/components/AuthorDetail.vue
+++ b/src/components/AuthorDetail.vue
@@ -68,7 +68,7 @@
                 :to="{
                   name: 'Case Study',
                   params: { id: usecase.id },
-                  query: addParamsToQuery(),
+                  query: $route.query,
                 }"
               >
                 <v-list-item-content>

--- a/src/components/CaseStudy.vue
+++ b/src/components/CaseStudy.vue
@@ -4,7 +4,7 @@
       <v-col cols="12" xl="8">
         <template v-if="!isLoading">
           <p class="text-h7 grey--text">
-            <v-btn icon plain :to="{ name: 'Studies' }">
+            <v-btn icon plain :to="{ name: 'Case Studies' }">
               <v-icon>mdi-chevron-left</v-icon>
             </v-btn>
             CASE STUDY<span v-if="study.principal_investigator"

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -34,7 +34,7 @@
                 large
                 block
                 color="secondary"
-                :to="{ name: $store.state.interface.currentView, query: addParamsToQuery() }"
+                :to="{ name: $store.state.interface.currentView, query: $route.query }"
                 >Search our Data</v-btn
               >
               <span class="button-subtitle"> For Interactive Analyses </span>
@@ -45,7 +45,7 @@
                   large
                   block
                   color="primary"
-                  :to="{ name: 'Case Study', params: { id: 6 }, query: addParamsToQuery() }"
+                  :to="{ name: 'Case Study', params: { id: 6 }, query: $route.query }"
                   >Read &bdquo;Spain and the Bible&ldquo;</v-btn
                 >
                 <span class="button-subtitle"> A Case Study </span>

--- a/src/components/KeywordDetail.vue
+++ b/src/components/KeywordDetail.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-navigation-drawer permanent fixed right color="#F1F5FA" :width="drawerWidth">
+  <v-navigation-drawer permanent fixed right color="#f1f5fa" :width="drawerWidth">
     <v-list-item>
       <v-list-item-action>
         <router-link :to="{ name: xPressLinkName, query: $route.query }">
@@ -7,9 +7,9 @@
         </router-link>
       </v-list-item-action>
       <v-list-item-content>
-        <div v-if="!loading.keywords && !loading.passages">
+        <div v-if="!isLoading">
           <v-list-item-title class="text-h5">
-            {{ data.keywords.map((x) => x.stichwort).join(', ') }}
+            {{ keywords.map((x) => x.stichwort).join(', ') }}
           </v-list-item-title>
           <v-list-item-subtitle>
             Mentioned in
@@ -19,9 +19,9 @@
                 query: addParamsToQuery({ Keyword: $route.params.id }),
               }"
             >
-              <span v-if="data.passages">
-                {{ data.passages.count }} passage{{ data.passages.count === 1 ? '' : 's'
-                }}<v-icon small>mdi-link</v-icon>,
+              <span v-if="passageCount">
+                {{ passageCount }} passage{{ passageCount === 1 ? '' : 's' }}
+                <v-icon small>mdi-link</v-icon>,
               </span>
             </router-link>
             <router-link
@@ -47,11 +47,11 @@
           </v-tabs>
           <v-tabs-items v-model="tab" background-color="transparent">
             <v-tab-item key="Over Time">
-              <keyword-over-time v-if="!loading.overtime" :data="data.overtime" />
+              <keyword-over-time v-if="!isLoading" :data="overtime" />
               <v-skeleton-loader v-else type="image@2" />
             </v-tab-item>
             <v-tab-item key="Geography">
-              <leaflet v-if="!loading.geography" :data="data.geography" height="400" />
+              <leaflet v-if="!isLoading" :data="geography" height="400" />
               <v-skeleton-loader v-else type="image@2" />
             </v-tab-item>
           </v-tabs-items>
@@ -59,11 +59,11 @@
       </v-row>
       <v-row>
         <v-col>
-          <v-expansion-panels v-if="!loading.else" accordion flat>
+          <v-expansion-panels v-if="!isLoading" accordion flat>
             <v-expansion-panel v-for="conn in connections" :key="conn.id">
               <v-expansion-panel-header>
                 <span>
-                  {{ data.keywords.map((x) => x.stichwort).join(', ') }}
+                  {{ keywords.map((x) => x.stichwort).join(', ') }}
                   <v-icon small>mdi-arrow-left-right</v-icon> {{ conn.label }}
                 </span>
                 <template #actions>
@@ -73,7 +73,7 @@
               </v-expansion-panel-header>
               <v-expansion-panel-content>
                 <keyword-list-item
-                  :parent-nodes="data.keywords.map((x) => x.id)"
+                  :parent-nodes="keywords.map((x) => x.id)"
                   :sibling-node="conn.id"
                 />
               </v-expansion-panel-content>
@@ -84,7 +84,7 @@
       </v-row>
       <v-row>
         <v-col>
-          <template v-if="!loading.keywords">
+          <template v-if="!isLoading">
             <v-row>
               <v-col>
                 <v-btn
@@ -95,13 +95,13 @@
                   :to="{
                     name: fullscreen ? 'List Fullscreen' : 'List',
                     query: addParamsToQuery({
-                      Keyword: data.keywords.map((x) => x.id).join('+'),
+                      Keyword: keywords.map((x) => x.id).join('+'),
                     }),
                   }"
                 >
                   {{
                     shorten(
-                      `Show all Passages for ${data.keywords.map((x) => x.stichwort).join(', ')}`,
+                      `Show all Passages for ${keywords.map((x) => x.stichwort).join(', ')}`,
                       40
                     )
                   }}
@@ -134,7 +134,18 @@
 </template>
 
 <script>
+import { computed } from 'vue';
+import { useRoute } from 'vue-router/composables';
+
+import {
+  useKeywordByCenturyById,
+  useKeywordById,
+  useKeywordGraph,
+  usePassages,
+  useSpatialCoveragesGeojson,
+} from '@/api';
 import helpers from '@/helpers';
+import { useStore } from '@/lib/use-store';
 
 import KeywordListItem from './KeywordListItem';
 import KeywordOverTime from './KeywordOverTime';
@@ -148,19 +159,59 @@ export default {
     Leaflet,
   },
   mixins: [helpers],
+  setup() {
+    const route = useRoute();
+    const store = useStore();
+    // FIXME: does this really accept multiple ids?
+    const id = computed(() => Number(route.params.id));
+
+    const keywordQuery = useKeywordById({ id });
+    const keywordByCenturyQuery = useKeywordByCenturyById({ id });
+    const keywordGraphQuery = useKeywordGraph({ id });
+    const passagesQuery = usePassages(
+      computed(() => ({
+        [store.state.apiParams.intersect ? 'key_word_and' : 'key_word']: id.value,
+      }))
+    );
+    const spatialCoveragesQuery = useSpatialCoveragesGeojson(
+      computed(() => ({
+        // FIXME: should this respect apiParams.intersect?
+        key_word: id.value,
+      }))
+    );
+
+    // TODO: granular loading states
+    const isLoading = computed(() => {
+      return [
+        keywordQuery,
+        keywordByCenturyQuery,
+        keywordGraphQuery,
+        passagesQuery,
+        spatialCoveragesQuery,
+      ].some((query) => {
+        return query.isInitialLoading.value;
+      });
+    });
+
+    const keyword = computed(() => keywordQuery.data.value);
+    const keywordByCentury = computed(() => keywordByCenturyQuery.data.value);
+    const keywordGraph = computed(() => keywordGraphQuery.data.value);
+    const passages = computed(() => passagesQuery.data.value?.results ?? []);
+    const spatialCoverages = computed(() => spatialCoveragesQuery.data.value?.features ?? []);
+
+    return {
+      isLoading,
+
+      keywords: keyword,
+      overtime: keywordByCentury,
+
+      graph: keywordGraph,
+      passages,
+      passageCount: passagesQuery.data.value?.count,
+      geography: spatialCoverages,
+    };
+  },
   data: () => ({
-    loading: {
-      keywords: true,
-      overtime: true,
-      else: true,
-    },
-    data: {
-      overtime: [],
-      geography: null,
-      keywords: [],
-      url: '',
-      passages: { count: 0 },
-    },
     tab: null,
   }),
   computed: {
@@ -168,10 +219,10 @@ export default {
       console.log('keyword connections called', this.data);
       const retArr = [];
 
-      if (!this.data.keywords || !this.data.nodes) return retArr;
+      if (!this.keywords || !this.graph) return retArr;
 
-      // const keyIds = this.data.keywords.map((x) => x.id);
-      const edges = this.data.nodes.edges.map((edge) => ({
+      // const keyIds = this.keywords.map((x) => x.id);
+      const edges = this.graph.edges.map((edge) => ({
         source: this.getIdFromUrl(edge.source),
         target: this.getIdFromUrl(edge.target),
       }));
@@ -189,7 +240,7 @@ export default {
         retArr.push({
           id: entry[0],
           label: this.removeRoot(
-            this.data.nodes.nodes.filter((node) => this.getIdFromUrl(node.id) === entry[0])[0].label
+            this.graph.nodes.filter((node) => this.getIdFromUrl(node.id) === entry[0])[0].label
           ),
           count: entry[1],
         });
@@ -211,122 +262,6 @@ export default {
       }
       if (this.fullscreen) return 'Network Graph Beta Fullscreen';
       return 'Network Graph Beta';
-    },
-  },
-  watch: {
-    '$route.params': {
-      handler(params) {
-        console.log(params);
-
-        // set all keys to true
-        Object.keys(this.loading).forEach((x) => {
-          this.loading[x] = true;
-        });
-
-        const ids = params.id.toString(10).split('+');
-
-        // Keywords
-        let urls = ids.map(
-          (x) => `${import.meta.env.VITE_APP_MMP_API_BASE_URL}/api/keyword/${x}/?format=json`
-        );
-        let prefetched = this.$store.state.fetchedResults[urls.toString()];
-        if (prefetched) {
-          this.data.keywords = prefetched;
-        } else {
-          Promise.all(urls.map((x) => fetch(x)))
-            .then((res) => {
-              Promise.all(res.map((x) => x.json()))
-                .then((jsonRes) => {
-                  console.log('promise all keyword1', jsonRes);
-                  this.$store.commit('addToResults', { req: urls.toString(), res: jsonRes });
-                  this.data.keywords = jsonRes;
-                })
-                .catch((err) => {
-                  console.error(err);
-                })
-                .finally(() => {
-                  this.loading.keywords = false;
-                });
-            })
-            .catch((err) => {
-              console.error(err);
-            });
-        }
-
-        // Overtime
-        urls = ids.map(
-          (x) => `${import.meta.env.VITE_APP_MMP_API_BASE_URL}/archiv/keyword/century/${x}`
-        );
-        prefetched = this.$store.state.fetchedResults[urls.toString()];
-        if (prefetched) {
-          this.data.overtime = prefetched;
-        } else {
-          Promise.all(urls.map((x) => fetch(x)))
-            .then((res) => {
-              Promise.all(res.map((x) => x.json()))
-                .then((jsonRes) => {
-                  console.log('promise all overtimes', jsonRes);
-                  this.$store.commit('addToResults', { req: urls.toString(), res: jsonRes });
-                  this.data.overtime = jsonRes;
-                })
-                .catch((err) => {
-                  console.error(err);
-                })
-                .finally(() => {
-                  this.loading.overtime = false;
-                });
-            })
-            .catch((err) => {
-              console.error(err);
-            });
-        }
-
-        // Else
-        urls = [
-          `${import.meta.env.VITE_APP_MMP_API_BASE_URL}/archiv/keyword-network/?ids=${ids.join(
-            ','
-          )}`,
-          `${import.meta.env.VITE_APP_MMP_API_BASE_URL}/api/stelle/?format=json&has_usecase=${
-            this.hasUsecase
-          }`,
-          `${import.meta.env.VITE_APP_MMP_API_BASE_URL}/api/spatialcoverage/?format=json`,
-        ];
-
-        ids.forEach((x) => {
-          urls[1] += this.$store.state.apiParams.intersect
-            ? `&key_word_and=${x}`
-            : `&key_word=${x}`;
-          urls[2] += `&key_word=${x}`;
-        });
-
-        prefetched = this.$store.state.fetchedResults[urls.toString()];
-        if (prefetched) {
-          [this.data.nodes, this.data.passages, , this.data.geography] = prefetched;
-        } else {
-          Promise.all(urls.map((x) => fetch(x)))
-            .then((res) => {
-              Promise.all(res.map((x) => x.json()))
-                .then((jsonRes) => {
-                  console.log('promise all keyword-', jsonRes);
-                  this.$store.commit('addToResults', { req: urls.toString(), res: jsonRes });
-                  [this.data.nodes, this.data.passages, , this.data.geography] = jsonRes;
-                  console.log('keyword data', this.data);
-                  // console.log('connections', this.connections);
-                })
-                .catch((err) => {
-                  console.error(err);
-                })
-                .finally(() => {
-                  this.loading.else = false;
-                });
-            })
-            .catch((err) => {
-              console.error(err);
-            });
-        }
-      },
-      deep: true,
-      immediate: true,
     },
   },
 };

--- a/src/components/KeywordDetail.vue
+++ b/src/components/KeywordDetail.vue
@@ -51,9 +51,7 @@
               <v-skeleton-loader v-else type="image@2" />
             </v-tab-item>
             <v-tab-item key="Geography">
-              <!-- TODO: leaflet currently expects to always be wrapped in mapwrapper (expects $root.$refs.mapwrap) -->
-              <!-- <leaflet v-if="!isLoading" :data="geography" height="400" /> -->
-              <div v-if="!isLoading">Not yet implemented</div>
+              <leaflet v-if="!isLoading" :data="geography" />
               <v-skeleton-loader v-else type="image@2" />
             </v-tab-item>
           </v-tabs-items>
@@ -151,14 +149,14 @@ import { useStore } from '@/lib/use-store';
 
 import KeywordListItem from './KeywordListItem';
 import KeywordOverTime from './KeywordOverTime';
-// import Leaflet from './Leaflet';
+import Leaflet from './Leaflet';
 
 export default {
   name: 'KeywordDetail',
   components: {
     KeywordListItem,
     KeywordOverTime,
-    // Leaflet,
+    Leaflet,
   },
   mixins: [helpers],
   setup() {
@@ -215,6 +213,10 @@ export default {
       return [keywordByCentury.value];
     });
 
+    const geography = computed(() => {
+      return [{ features: spatialCoverages.value }, { features: [] }];
+    });
+
     return {
       isLoading,
 
@@ -224,7 +226,7 @@ export default {
       graph: keywordGraph,
       passages,
       passageCount: passagesQuery.data.value?.count,
-      geography: spatialCoverages,
+      geography,
     };
   },
   data: () => ({

--- a/src/components/KeywordListItem.vue
+++ b/src/components/KeywordListItem.vue
@@ -62,7 +62,6 @@ export default {
 
     const isLoading = computed(() => passagesQuery.isInitialLoading.value);
 
-    // FIXME: why removeDuplicates(passages, 'url');
     const passages = computed(() => passagesQuery.data.value?.results ?? []);
 
     return {

--- a/src/components/KeywordListItem.vue
+++ b/src/components/KeywordListItem.vue
@@ -21,11 +21,11 @@
           <v-list-item-title>
             {{ passage.display_label }}
           </v-list-item-title>
-          <v-list-item-subtitle v-if="passage.text.autor.length">
+          <v-list-item-subtitle v-if="passage.text?.autor?.length">
             {{ passage.text.title }},
             {{ passage.text.autor.map((x) => getOptimalName(x)).join(', ') }}
           </v-list-item-subtitle>
-          <v-list-item-subtitle v-if="passage.text.jahrhundert">
+          <v-list-item-subtitle v-if="passage.text?.jahrhundert">
             {{ passage.text.jahrhundert }} century
           </v-list-item-subtitle>
         </v-list-item-content>

--- a/src/components/KeywordListItem.vue
+++ b/src/components/KeywordListItem.vue
@@ -2,7 +2,7 @@
   <v-card flat color="rgba(0, 0, 0, 0)">
     <v-list two-line>
       <v-skeleton-loader
-        v-if="loading"
+        v-if="isLoading"
         type="list-item-three-line@3"
         class="transparent-skeleton"
       />
@@ -38,50 +38,37 @@
   </v-card>
 </template>
 <script>
+import { computed } from 'vue';
+
+import { usePassages } from '@/api';
 import helpers from '@/helpers';
+import { useStore } from '@/lib/use-store';
 
 export default {
   mixins: [helpers],
   props: ['parentNodes', 'siblingNode'],
-  data: () => ({
-    data: [],
-    loading: true,
-  }),
-  mounted() {
-    const { intersect } = this.$store.state.apiParams;
-    let url = `${import.meta.env.VITE_APP_MMP_API_BASE_URL}/api/stelle/?${
-      intersect ? 'key_word_and' : 'key_word'
-    }=${this.siblingNode}&has_usecase=${this.hasUsecase}`;
-    this.parentNodes.forEach((x) => {
-      url += intersect ? `&key_word_and=${x}` : `&key_word=${x}`;
-    });
+  setup(props) {
+    const store = useStore();
 
-    const prefetched = this.$store.state.fetchedResults[url];
-    if (prefetched) {
-      this.loading = false;
-      // const texts = prefetched.results.map((x) => ({ ...x.text, keywords: x.key_word }));
-      const passages = prefetched.results;
-      console.log('stored passages', passages);
-      this.data = this.removeDuplicates(passages, 'url');
-    } else {
-      fetch(url)
-        .then((res) => res.json())
-        .then((jsonRes) => {
-          this.$store.commit('addToResults', { req: url, jsonRes });
+    const passagesQuery = usePassages(
+      computed(() => ({
+        [store.state.apiParams.intersect ? 'key_word_and' : 'key_word']: [
+          props.siblingNode,
+          ...props.parentNodes,
+        ],
+        has_usecase: store.state.apiParams.hasUsecase,
+      }))
+    );
 
-          // const texts = jsonRes.results.map((x) => ({ ...x.text, keywords: x.key_word }));
-          const passages = jsonRes.results;
-          console.log('passages', passages);
-          this.data = this.removeDuplicates(passages, 'url');
-          console.log('Keyword List Item data', this.data);
-        })
-        .catch((err) => {
-          console.error(err);
-        })
-        .finally(() => {
-          this.loading = false;
-        });
-    }
+    const isLoading = computed(() => passagesQuery.isInitialLoading.value);
+
+    // FIXME: why removeDuplicates(passages, 'url');
+    const passages = computed(() => passagesQuery.data.value?.results ?? []);
+
+    return {
+      isLoading,
+      data: passages,
+    };
   },
 };
 </script>

--- a/src/components/Leaflet.vue
+++ b/src/components/Leaflet.vue
@@ -184,7 +184,7 @@
         </v-menu>
       </l-control>
       <l-geo-json
-        v-if="data[0] && showLayers.spatial && $root.$refs.mapWrap.$route.query['Use Case'] !== '3'"
+        v-if="data[0] && showLayers.spatial"
         ref="spatCov"
         :geojson="data[0]"
         :options="{ onEachFeature: onEach }"

--- a/src/components/Leaflet.vue
+++ b/src/components/Leaflet.vue
@@ -313,12 +313,6 @@ import blueMarker from '@/assets/blue_marker_icon.png';
 import greenMarker from '@/assets/recolored_marker_icon.png';
 import greenMarker2x from '@/assets/recolored_marker_icon_2x.png';
 import redMarker from '@/assets/red_marker_icon.png';
-import majorTowns800 from '@/assets/geojson/darmc-medieval-world-814.json';
-import majorTowns1000 from '@/assets/geojson/darmc-medieval-world-1000.json';
-import kingdoms800 from '@/assets/geojson/kingdoms-800.json';
-import kingdomsMid800 from '@/assets/geojson/kingdoms-mid-800.json';
-import langobards from '@/assets/geojson/langobards.json';
-import romanRoads from '@/assets/geojson/roman-roads.json';
 import helpers from '@/helpers';
 
 export default {
@@ -380,7 +374,7 @@ export default {
     sources: '',
     romanRoads: {},
     majorTowns: {},
-    langobardenPoints: JSON.parse(JSON.stringify(langobards)),
+    langobardenPoints: {},
     bounds: latLngBounds([
       [34.016242, 5.488281],
       [71.663663, 34.667969],
@@ -809,7 +803,7 @@ export default {
           const relatedCoords = this.relatedPlaces.map((x) => x.coords.coordinates);
           this.bounds = this.getBounds(allCoords.concat(relatedCoords));
 
-          this.romanRoads = JSON.parse(JSON.stringify(romanRoads));
+          this.romanRoads = {};
 
           this.polygonCenters = JSON.parse(JSON.stringify(to[0]));
           this.polygonCenters.features.forEach((feature) => {
@@ -911,42 +905,6 @@ export default {
               }
             });
           });
-        }
-
-        console.log(this.$route.query['Use Case'], 'hereee');
-
-        console.log(this.$store.state, this.$route.query['Use Case'], 'study');
-
-        const study = this.$route.query['Use Case'];
-        if (study) {
-          const url = `${
-            import.meta.env.VITE_APP_MMP_API_BASE_URL
-          }/api/usecase/${study}?format=json`;
-          fetch(url)
-            .then((res) => res.json())
-            .then((jsonRes) => {
-              const layer = jsonRes.custom_layer;
-              if (layer === '800') {
-                this.kingdomsLayer = JSON.parse(JSON.stringify(kingdoms800));
-                this.majorTowns = JSON.parse(JSON.stringify(majorTowns800));
-                this.sources =
-                  'Kingdoms:<br> Scientific direction Thomas Lienhard (Paris 1, LaMOP),<br> Production and classification of data, computer developments by Pierre Brochard (CNRS, LaMOP), Mathieu Beaud (Paris 1, LaMOP).<br><br> Roman Roads & Major Towns:<br> Michael McCormick et al. (eds.), The Digital Atlas of Roman and Medieval Civilizations, Cambridge (Massachusetts), 2007.';
-              } else if (layer === '850') {
-                this.kingdomsLayer = JSON.parse(JSON.stringify(kingdomsMid800));
-                this.majorTowns = JSON.parse(JSON.stringify(majorTowns1000));
-                this.sources =
-                  'Kingdoms:<br> Scientific direction Thomas Lienhard (Paris 1, LaMOP),<br> Production and classification of data, computer developments by Pierre Brochard (CNRS, LaMOP), Mathieu Beaud (Paris 1, LaMOP).<br><br> Roman Roads & Major Towns:<br> Michael McCormick et al. (eds.), The Digital Atlas of Roman and Medieval Civilizations, Cambridge (Massachusetts), 2007.';
-              }
-            })
-            .catch((err) => {
-              console.error(err);
-            })
-            .finally(() => {
-              this.loading = false;
-            });
-        } else {
-          this.sources =
-            'Roman Roads:<br> Michael McCormick et al. (eds.), The Digital Atlas of Roman and Medieval Civilizations, Cambridge (Massachusetts), 2007.';
         }
       },
       deep: true,

--- a/src/components/Leaflet.vue
+++ b/src/components/Leaflet.vue
@@ -279,7 +279,12 @@
         />
       </l-control>
     </l-map>
-    <v-overlay absolute class="overlay" opacity=".2" :value="loading || !data.some((d) => d.count)">
+    <v-overlay
+      absolute
+      class="overlay"
+      opacity=".2"
+      :value="loading || !data.some((d) => d.features.length)"
+    >
       <h1 v-if="!loading" class="no-nodes">No locations found!</h1>
       <h1 v-else>
         <v-progress-circular indeterminate color="#0F1226" />

--- a/src/components/MapWrapper.vue
+++ b/src/components/MapWrapper.vue
@@ -1,27 +1,18 @@
 <template>
   <v-card color="transparent" width="100%">
-    <leaflet :data="entries" :loading="loading" :usecase="usecase" />
-    <!-- <div v-for="(feature, i) in featureList">
-      <div
-      class="card"
-      :key="i+feature.properties.key_word.id"
-      data-toggle="collapse"
-      :data-target="`#${i+feature.properties.key_word.id}`"
-      >
-        <div class="card-header list">
-          {{ feature.properties.key_word.stichwort }}
-          <span class="badge badge-pill badge-primary">{{ feature.properties.stelle.length }}</span>
-        </div>
-      </div>
-      <div class="card-body collapse" :id="i+feature.properties.key_word.id">
-        <data-table :data="feature.properties.stelle" />
-      </div>
-    </div> -->
+    <leaflet :data="entries" :loading="isLoading" :usecase="usecase" />
     <router-view />
   </v-card>
 </template>
 
 <script>
+import { computed } from 'vue';
+import { useRoute } from 'vue-router/composables';
+
+import { useCaseStudyById, useConesGeojson, useSpatialCoveragesGeojson } from '@/api';
+import { isNotNullable } from '@/lib/is-not-nullable';
+import { useStore } from '@/lib/use-store';
+
 import Leaflet from './Leaflet';
 
 export default {
@@ -29,133 +20,86 @@ export default {
   components: {
     Leaflet,
   },
-  props: ['passage', 'author', 'keyword', 'place', 'usecase'],
-  data: () => ({
-    entries: [],
-    loading: false,
-  }),
-  watch: {
-    '$route.query': {
-      handler(query) {
-        let urls = [
-          `${import.meta.env.VITE_APP_MMP_API_BASE_URL}/api/spatialcoverage/?format=json`,
-          `${import.meta.env.VITE_APP_MMP_API_BASE_URL}/api/cones/?format=json`,
-        ];
-        const blankUrls = urls;
+  props: ['author', 'passage', 'keyword', 'usecase', 'place'],
+  setup(props) {
+    const route = useRoute();
+    const store = useStore();
 
-        const terms = {
-          Author: 'stelle__text__autor',
-          Passage: 'stelle',
-          Keyword: 'key_word',
-          'Use Case': 'stelle__use_case',
-          // Place: 'unused',
+    const searchFilters = computed(() => {
+      // FIXME:
+      if (Object.values(props).some(isNotNullable)) {
+        return {
+          stelle__text__autor: props.author,
+          stelle: props.passage,
+          key_word: props.keyword,
+          stelle__use_case: props.usecase,
+          // place ?
         };
+      }
 
-        const props = [this.author, this.passage, this.keyword, this.usecase, this.place];
+      function getDateFilters() {
+        if (route.query['time'] == null) return {};
 
-        console.log('map props', props);
+        const [start, end] = route.query['time'].toString().includes('+')
+          ? route.query['time'].split('+')
+          : [route.query['time'] - 5, route.query['time'] + 4];
 
-        if (props.some((x) => x)) {
-          console.debug('map props detected!');
-          props.forEach((prop, i) => {
-            if (prop && prop !== '0') {
-              console.debug('map prop', prop);
-              if (i === 4) {
-                // place
-                if (JSON.stringify(urls) === JSON.stringify(blankUrls)) {
-                  // prevents fetching every coverage if no other filters are applied
-                  urls = urls.map((x) => `${x}&id=0`);
-                }
-                urls.push(
-                  `${
-                    import.meta.env.VITE_APP_MMP_API_BASE_URL
-                  }/api/ort-geojson/?format=json&ids=${prop}`
-                );
-              } else {
-                urls = urls.map((url) => `${url}&${Object.values(terms)[i]}=${prop}`);
+        const dateFilters =
+          store.state.slider === 'passage'
+            ? {
+                stelle__start_date: start,
+                stelle__start_date_lookup: 'gt',
+                stelle__end_date: end,
+                stelle__end_date_lookup: 'lt',
               }
-            }
-          });
-        } else {
-          Object.keys(query).forEach((cat) => {
-            if (query[cat] && !['Place', 'time'].includes(cat)) {
-              const arr = query[cat].split('+');
-              arr.forEach((val) => {
-                urls = urls.map((url) => `${url}&${terms[cat]}=${val}`);
-              });
-            }
-          });
+            : {
+                stelle__text__not_before: start,
+                stelle__text__not_before_lookup: 'gt',
+                stelle__text__not_after: end,
+                stelle__text__not_after_lookup: 'lt',
+              };
 
-          if (query.time) {
-            const startKey =
-              this.$store.state.slider === 'passage'
-                ? 'stelle__start_date'
-                : 'stelle__text__not_before';
-            const endKey =
-              this.$store.state.slider === 'passage'
-                ? 'stelle__end_date'
-                : 'stelle__text__not_after';
+        return dateFilters;
+      }
 
-            if (query.time.toString().includes('+')) {
-              const times = query.time.split('+');
-              urls = urls.map(
-                (url) =>
-                  `${url}&${startKey}=${times[0]}&${startKey}_lookup=gt&${endKey}=${times[1]}&${endKey}_lookup=lt`
-              );
-            } else {
-              urls = urls.map(
-                (url) =>
-                  `${url}&${startKey}=${query.time - 5}&${startKey}_lookup=gt&${endKey}=${
-                    query.time + 4
-                  }&${endKey}_lookup=g`
-              );
-            }
-          }
-          if (query.Place) {
-            console.log('place detected');
-            if (JSON.stringify(urls) === JSON.stringify(blankUrls)) {
-              // prevents fetching every coverage if no other filters are applied
-              urls = urls.map((x) => `${x}&id=0`);
-            }
-            urls.push(
-              `${
-                import.meta.env.VITE_APP_MMP_API_BASE_URL
-              }/api/ort-geojson/?format=json&ids=${query.Place.split('+').join(',')}`
-            );
-          } else
-            urls.push(`${import.meta.env.VITE_APP_MMP_API_BASE_URL}/api/ort/?format=json&id=0`);
-        }
+      return {
+        stelle__text__autor: route.query['Author']?.toString().split('+').join(','),
+        stelle: route.query['Passage']?.toString().split('+').join(','),
+        key_word: route.query['Keyword']?.toString().split('+').join(','),
+        stelle__use_case: route.query['Use Case']?.toString().split('+').join(','),
+        // place ?,
+        ...getDateFilters(),
+        // TODO: respect other config options like intersect
+      };
+    });
 
-        console.log('map urls', urls);
+    const spatialCoveragesQuery = useSpatialCoveragesGeojson(searchFilters);
+    const conesQuery = useConesGeojson(searchFilters);
 
-        const prefetched = this.$store.state.fetchedResults[urls.toString()];
-        if (prefetched) {
-          this.entries = prefetched;
-        } else {
-          this.loading = true;
-          Promise.all(urls.map((x) => fetch(x)))
-            .then((res) => {
-              Promise.all(res.map((x) => x.json()))
-                .then((jsonRes) => {
-                  console.log('map-data', jsonRes);
-                  this.$store.commit('addToResults', { req: urls.toString(), res: jsonRes });
-                  this.entries = jsonRes;
-                })
-                .catch((err) => {
-                  console.error('err', err);
-                })
-                .finally(() => {
-                  this.loading = false;
-                });
-            })
-            .catch((err) => {
-              console.error('err', err);
-            });
-        }
-      },
-      deep: true,
-      immediate: true,
-    },
+    // FIXME: what if we have multiple case studies in route.query
+    const id = computed(() => ({ id: props.usecase ?? route.query['Use Case'] }));
+    const caseStudyQuery = useCaseStudyById({ id });
+
+    const isLoading = computed(() => {
+      return [spatialCoveragesQuery, conesQuery, caseStudyQuery].some(
+        (query) => query.isInitialLoading.value
+      );
+    });
+
+    const spatialCoverages = computed(() => spatialCoveragesQuery.data.value?.features ?? []);
+    const cones = computed(() => conesQuery.data.value?.features ?? []);
+
+    const layers = computed(() => caseStudyQuery.data.value?.layer ?? []);
+
+    return {
+      isLoading,
+      spatialCoverages,
+      cones,
+      layers,
+
+      // FIXME:
+      entries: [{ features: spatialCoverages }, { features: cones }],
+    };
   },
   created() {
     this.$root.$refs.mapWrap = this;

--- a/src/components/MapWrapper.vue
+++ b/src/components/MapWrapper.vue
@@ -28,12 +28,13 @@ export default {
     const searchFilters = computed(() => {
       // FIXME:
       if (Object.values(props).some(isNotNullable)) {
+        /** @type {import('@/api').SpatialCoverageSearchParams} */
         return {
           stelle__text__autor: props.author,
           stelle: props.passage,
           key_word: props.keyword,
           stelle__use_case: props.usecase,
-          // place ?
+          stelle__ort: props.place,
         };
       }
 
@@ -67,7 +68,7 @@ export default {
         stelle: route.query['Passage']?.toString().split('+').join(','),
         key_word: route.query['Keyword']?.toString().split('+').join(','),
         stelle__use_case: route.query['Use Case']?.toString().split('+').join(','),
-        // place ?,
+        stelle__ort: route.query['Place']?.toString().split('+').join(','),
         ...getDateFilters(),
         // TODO: respect other config options like intersect
       };

--- a/src/components/MapWrapper.vue
+++ b/src/components/MapWrapper.vue
@@ -76,20 +76,26 @@ export default {
     const spatialCoveragesQuery = useSpatialCoveragesGeojson(searchFilters);
     const conesQuery = useConesGeojson(searchFilters);
 
-    // FIXME: what if we have multiple case studies in route.query
-    const id = computed(() => ({ id: props.usecase ?? route.query['Use Case'] }));
-    const caseStudyQuery = useCaseStudyById({ id });
-
     const isLoading = computed(() => {
-      return [spatialCoveragesQuery, conesQuery, caseStudyQuery].some(
-        (query) => query.isInitialLoading.value
-      );
+      return [spatialCoveragesQuery, conesQuery].some((query) => query.isInitialLoading.value);
     });
 
     const spatialCoverages = computed(() => spatialCoveragesQuery.data.value?.features ?? []);
     const cones = computed(() => conesQuery.data.value?.features ?? []);
 
+    // FIXME: what if we have multiple case studies in route.query
+    const id = computed(() => props.usecase ?? route.query['Use Case']);
+    const caseStudyQuery = useCaseStudyById(
+      { id },
+      { isEnabled: computed(() => id.value != null) }
+    );
+
     const layers = computed(() => caseStudyQuery.data.value?.layer ?? []);
+
+    // FIXME: only temporary because the map component requires this shape
+    const entries = computed(() => {
+      return [{ features: spatialCoverages.value }, { features: cones.value }];
+    });
 
     return {
       isLoading,
@@ -97,8 +103,7 @@ export default {
       cones,
       layers,
 
-      // FIXME:
-      entries: [{ features: spatialCoverages }, { features: cones }],
+      entries,
     };
   },
   created() {

--- a/src/components/PlaceDetail.vue
+++ b/src/components/PlaceDetail.vue
@@ -10,34 +10,34 @@
         </router-link>
       </v-list-item-action>
       <v-list-item-content>
-        <template v-if="!loading">
+        <template v-if="!isLoading">
           <v-list-item-title class="text-h5">
-            {{ getOptimalName(data.ort) }}
+            {{ getOptimalName(place) }}
           </v-list-item-title>
-          <v-list-item-subtitle v-if="data.ort.name_antik">
-            {{ data.ort.name_antik }}
+          <v-list-item-subtitle v-if="place.name_antik">
+            {{ place.name_antik }}
           </v-list-item-subtitle>
-          <v-list-item-subtitle> {{ data.ort.lat }}, {{ data.ort.long }} </v-list-item-subtitle>
+          <v-list-item-subtitle> {{ place.lat }}, {{ place.long }} </v-list-item-subtitle>
         </template>
         <v-skeleton-loader v-else type="heading, text@2" />
       </v-list-item-content>
     </v-list-item>
     <v-divider />
     <v-container>
-      <v-expansion-panels v-if="!loading" flat accordion multiple :value="[0, 1]">
-        <v-expansion-panel :disabled="!data.authors.count">
+      <v-expansion-panels v-if="!isLoading" flat accordion multiple :value="[0, 1]">
+        <v-expansion-panel :disabled="!authorCount">
           <v-expansion-panel-header>
             <template #actions>
-              <v-chip small color="red lighten-3" :disabled="!data.authors.count">{{
-                data.authors.count
-              }}</v-chip>
+              <v-chip small color="red lighten-3" :disabled="!authorCount">
+                {{ authorCount }}
+              </v-chip>
               <v-icon>mdi-chevron-down</v-icon>
             </template>
             Authors
           </v-expansion-panel-header>
           <v-expansion-panel-content>
             <v-list-item
-              v-for="author in data.authors.results"
+              v-for="author in authors"
               :key="author.id"
               :to="{
                 name: fullscreen ? 'Author Detail Fullscreen' : 'Author Detail',
@@ -47,9 +47,9 @@
             >
               <v-list-item-content>
                 <v-list-item-title>{{ getOptimalName(author) }}</v-list-item-title>
-                <v-list-item-subtitle v-if="author.kommentar">{{
-                  author.kommentar
-                }}</v-list-item-subtitle>
+                <v-list-item-subtitle v-if="author.kommentar">
+                  {{ author.kommentar }}
+                </v-list-item-subtitle>
                 <v-list-item-subtitle>{{ author.jahrhundert }}</v-list-item-subtitle>
               </v-list-item-content>
               <v-list-item-icon>
@@ -58,23 +58,23 @@
             </v-list-item>
           </v-expansion-panel-content>
         </v-expansion-panel>
-        <v-expansion-panel :disabled="!data.texts.count">
+        <v-expansion-panel :disabled="!textCount">
           <v-expansion-panel-header>
             <template #actions>
-              <v-chip small color="red darken-3" dark :disabled="!data.texts.count">
-                {{ data.texts.count }}
+              <v-chip small color="red darken-3" dark :disabled="!textCount">
+                {{ textCount }}
               </v-chip>
               <v-icon>mdi-chevron-down</v-icon>
             </template>
             Texts
           </v-expansion-panel-header>
           <v-expansion-panel-content>
-            <v-list-item v-for="text in data.texts.results" :key="text.id" two-line>
+            <v-list-item v-for="text in texts" :key="text.id" two-line>
               <v-list-item-content>
                 <v-list-item-title>{{ text.title }}</v-list-item-title>
-                <v-list-item-subtitle>{{
-                  text.autor.map((x) => getOptimalName(x)).join(', ')
-                }}</v-list-item-subtitle>
+                <v-list-item-subtitle>
+                  {{ text.autor.map((x) => getOptimalName(x)).join(', ') }}
+                </v-list-item-subtitle>
                 <v-list-item-subtitle>{{ text.jahrhundert }}</v-list-item-subtitle>
               </v-list-item-content>
             </v-list-item>
@@ -87,58 +87,54 @@
 </template>
 
 <script>
+import { computed } from 'vue';
+import { useRoute } from 'vue-router/composables';
+
+import { useAuthors, usePlaceById, useTexts } from '@/api';
 import helpers from '@/helpers';
+import { useStore } from '@/lib/use-store';
 
 export default {
   name: 'PlaceDetail',
   mixins: [helpers],
-  data: () => ({
-    loading: false,
-    data: {
-      place: null,
-      texts: null,
-      authors: null,
-    },
-  }),
-  watch: {
-    '$route.params': {
-      handler(params) {
-        console.log('place params', params);
-        this.loading = true;
-        const urls = [
-          `${import.meta.env.VITE_APP_MMP_API_BASE_URL}/api/ort/${params.id}/?format=json`,
-          `${import.meta.env.VITE_APP_MMP_API_BASE_URL}/api/text/?ort=${
-            params.id
-          }&format=json&has_usecase=${this.hasUsecase}`,
-          `${import.meta.env.VITE_APP_MMP_API_BASE_URL}/api/autor/?ort=${
-            params.id
-          }&format=json&has_usecase=${this.hasUsecase}`,
-        ];
-        const prefetched = this.$store.state.fetchedResults[urls.toString()];
+  setup() {
+    const route = useRoute();
+    const store = useStore();
+    const id = computed(() => Number(route.params.id));
 
-        if (prefetched) {
-          console.log('prefetched places', prefetched);
-          this.loading = false;
-        } else {
-          Promise.all(urls.map((x) => fetch(x))).then((res) => {
-            Promise.all(res.map((x) => x.json()))
-              .then((jsonRes) => {
-                console.log('place res', jsonRes);
-                this.$store.commit('addToResults', { req: urls.toString(), jsonRes });
-                [this.data.ort, this.data.texts, this.data.authors] = jsonRes;
-              })
-              .catch((err) => {
-                console.error(err);
-              })
-              .finally(() => {
-                this.loading = false;
-              });
-          });
-        }
-      },
-      deep: true,
-      immediate: true,
-    },
+    const placeQuery = usePlaceById({ id });
+    const textsQuery = useTexts(
+      computed(() => ({
+        ort: id.value,
+        has_usecase: store.state.apiParams.hasUsecase,
+      }))
+    );
+    const authorsQuery = useAuthors(
+      computed(() => ({
+        ort: id.value,
+        has_usecase: store.state.apiParams.hasUsecase,
+      }))
+    );
+
+    const isLoading = computed(() => {
+      return [placeQuery, textsQuery, authorsQuery].some((query) => query.isInitialLoading.value);
+    });
+
+    const place = computed(() => placeQuery.data.value);
+    const texts = computed(() => textsQuery.data.value?.results ?? []);
+    const authors = computed(() => authorsQuery.data.value?.results ?? []);
+
+    const textCount = computed(() => textsQuery.data.value?.count);
+    const authorCount = computed(() => authorsQuery.data.value?.count);
+
+    return {
+      isLoading,
+      place,
+      texts,
+      authors,
+      textCount,
+      authorCount,
+    };
   },
 };
 </script>

--- a/src/components/PlaceDetail.vue
+++ b/src/components/PlaceDetail.vue
@@ -24,6 +24,11 @@
     </v-list-item>
     <v-divider />
     <v-container>
+      <div :style="{ height: '400px' }">
+        <place-map :point="{ lat: place.lat, lng: place.long }" />
+      </div>
+    </v-container>
+    <v-container>
       <v-expansion-panels v-if="!isLoading" flat accordion multiple :value="[0, 1]">
         <v-expansion-panel :disabled="!authorCount">
           <v-expansion-panel-header>
@@ -91,11 +96,13 @@ import { computed } from 'vue';
 import { useRoute } from 'vue-router/composables';
 
 import { useAuthors, usePlaceById, useTexts } from '@/api';
+import PlaceMap from '@/components/PlaceMap.vue';
 import helpers from '@/helpers';
 import { useStore } from '@/lib/use-store';
 
 export default {
   name: 'PlaceDetail',
+  components: { PlaceMap },
   mixins: [helpers],
   setup() {
     const route = useRoute();

--- a/src/components/PlaceMap.vue
+++ b/src/components/PlaceMap.vue
@@ -1,0 +1,28 @@
+<script lang="ts" setup>
+import 'leaflet/dist/leaflet.css';
+
+import { LMap, LMarker, LTileLayer } from 'vue2-leaflet';
+
+const _props = defineProps<{
+  point: { lat: number; lng: number };
+}>();
+
+const baseLayer = {
+  url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+  attribution:
+    'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
+};
+</script>
+
+<template>
+  <l-map
+    height="400"
+    :bounds="[
+      [34.016242, 5.488281],
+      [71.663663, 34.667969],
+    ]"
+  >
+    <l-tile-layer :url="baseLayer.url" :attribution="baseLayer.attribution" />
+    <l-marker :lat-lng="[point.lat, point.lng]" />
+  </l-map>
+</template>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -9,7 +9,7 @@
       <v-list-item-content>
         <v-list-item-title class="text-h4 font-weight-bold">
           <v-icon @click.prevent="$store.commit('toggleDrawer')">mdi-close</v-icon>
-          <router-link :to="{ name: 'Home', query: addParamsToQuery() }"> MMP </router-link>
+          <router-link :to="{ name: 'Home', query: $route.query }"> MMP </router-link>
         </v-list-item-title>
       </v-list-item-content>
     </v-list-item>
@@ -22,15 +22,12 @@
           <v-list-item-title>About the Project</v-list-item-title>
         </v-list-item-content>
       </v-list-item>
-      <v-list-item :to="{ name: 'Studies', query: addParamsToQuery() }" link>
+      <v-list-item :to="{ name: 'Studies', query: $route.query }" link>
         <v-list-item-content>
           <v-list-item-title>Case Studies</v-list-item-title>
         </v-list-item-content>
       </v-list-item>
-      <v-list-item
-        :to="{ name: $store.state.interface.currentView, query: addParamsToQuery() }"
-        link
-      >
+      <v-list-item :to="{ name: $store.state.interface.currentView, query: $route.query }" link>
         <v-list-item-content>
           <v-list-item-title>Explore the Data</v-list-item-title>
         </v-list-item-content>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -22,7 +22,7 @@
           <v-list-item-title>About the Project</v-list-item-title>
         </v-list-item-content>
       </v-list-item>
-      <v-list-item :to="{ name: 'Studies', query: $route.query }" link>
+      <v-list-item :to="{ name: 'Case Studies', query: $route.query }" link>
         <v-list-item-content>
           <v-list-item-title>Case Studies</v-list-item-title>
         </v-list-item-content>

--- a/src/components/SpatialDetail.vue
+++ b/src/components/SpatialDetail.vue
@@ -12,19 +12,16 @@
       <v-list-item-title> Keyword(s) found at point </v-list-item-title>
     </v-list-item>
     <v-divider />
-    <v-list v-if="!loading" v-model="data">
+    <v-list v-if="!isLoading" v-model="data">
       <v-list v-for="d in data" :key="d.id">
         <v-list-item @mouseover="highlightSpatCov(d.id)" @mouseout="playdownSpatCov(d.id)">
           <v-list-item-content>
-            <template v-if="!loading">
-              <v-list-item-title class="text-h5">
-                Keyword: {{ d.properties.key_word.stichwort }}
-              </v-list-item-title>
-              <v-list-item-subtitle>
-                {{ d.properties.key_word.art }}
-              </v-list-item-subtitle>
-            </template>
-            <v-skeleton-loader v-else type="heading, text@2" />
+            <v-list-item-title class="text-h5">
+              Keyword: {{ d.properties.key_word.stichwort }}
+            </v-list-item-title>
+            <v-list-item-subtitle>
+              {{ d.properties.key_word.art }}
+            </v-list-item-subtitle>
           </v-list-item-content>
         </v-list-item>
         <v-subheader hide-details>Texts</v-subheader>
@@ -81,55 +78,33 @@
 </template>
 
 <script>
+import { computed } from 'vue';
+import { useRoute } from 'vue-router/composables';
+
+import { useSpatialCoverageGeojsonById } from '@/api';
 import helpers from '@/helpers';
 
 export default {
   name: 'SpatialDetails',
   mixins: [helpers],
+  setup() {
+    const route = useRoute();
+    const id = computed(() => Number(route.params.id));
+
+    const spatialCoverageQuery = useSpatialCoverageGeojsonById({ id });
+
+    const isLoading = computed(() => spatialCoverageQuery.isInitialLoading.value);
+
+    const spatialCoverage = computed(() => spatialCoverageQuery.data.value);
+
+    return {
+      isLoading,
+      data: [spatialCoverage],
+    };
+  },
   data: () => ({
-    loading: false,
-    data: [],
     strokeColor: '',
   }),
-  watch: {
-    '$route.params': {
-      handler(params) {
-        let arr = JSON.parse(params.id);
-        if (typeof arr === 'number') {
-          const arr2 = [arr];
-          arr = arr2;
-        }
-        console.log('place params', params, typeof params, arr, typeof arr);
-        this.data = [];
-        arr.forEach((param) => {
-          this.loading = true;
-          const address = `${
-            import.meta.env.VITE_APP_MMP_API_BASE_URL
-          }/api/spatialcoverage/${param}`;
-          const prefetched = this.$store.state.fetchedResults[address];
-          if (prefetched) {
-            this.data.push(prefetched);
-            this.loading = false;
-          } else {
-            fetch(address)
-              .then((res) => res.json())
-              .then((jsonRes) => {
-                this.data.push(jsonRes);
-                this.$store.commit('addToResults', { req: address, res: jsonRes });
-              })
-              .catch((err) => {
-                console.error(err);
-              })
-              .finally(() => {
-                this.loading = false;
-              });
-          }
-        });
-      },
-      deep: true,
-      immediate: true,
-    },
-  },
   methods: {
     highlightSpatCov(id) {
       if (this.$root.$refs.map.$refs.spatCov !== undefined) {
@@ -137,6 +112,7 @@ export default {
       } else {
         this.$root.$refs.map.enableSpatCov(id);
       }
+
       if (document.getElementsByClassName(`labelText ${id}`)[0]) {
         const colour = 'rgb(255,255,0)';
 

--- a/src/components/SpatialDetail.vue
+++ b/src/components/SpatialDetail.vue
@@ -89,7 +89,13 @@ export default {
   mixins: [helpers],
   setup() {
     const route = useRoute();
-    const id = computed(() => Number(route.params.id));
+    // FIXME: currently the map view encodes multiple ids as path param when a point is clicked
+    // which has multiple overlapping spatial coverages, which is a really bad idea
+    const id = computed(() =>
+      route.params.id.startsWith('[')
+        ? route.params.id.slice(1, -1).split(',').map(Number)[0]
+        : Number(route.params.id)
+    );
 
     const spatialCoverageQuery = useSpatialCoverageGeojsonById({ id });
 
@@ -97,9 +103,15 @@ export default {
 
     const spatialCoverage = computed(() => spatialCoverageQuery.data.value);
 
+    // FIXME: only temporary
+    const data = computed(() => {
+      if (spatialCoverage.value == null) return [];
+      return [spatialCoverage.value];
+    });
+
     return {
       isLoading,
-      data: [spatialCoverage],
+      data,
     };
   },
   data: () => ({

--- a/src/components/Studies.vue
+++ b/src/components/Studies.vue
@@ -18,7 +18,7 @@
           no-data-text="No data found"
           :items="studySearch"
           :search-input.sync="textInput"
-          :loading="loading"
+          :loading="isLoading"
           @change="textInput = ''"
           @keyup.enter="pushQuery"
         >
@@ -28,9 +28,9 @@
             >
               <v-list-item-title>
                 {{ removeRoot(data.item.selected_text) }}
-                <span v-if="$store.state.completeKeywords.includes(parseInt(data.item.id))"
-                  >(complete)</span
-                >
+                <span v-if="$store.state.completeKeywords.includes(parseInt(data.item.id))">
+                  (complete)
+                </span>
               </v-list-item-title>
               <v-list-item-subtitle
                 >Keyword ({{ data.item.selected_text.split(',')[1].replace(/\W/g, '') }})
@@ -42,9 +42,9 @@
             </v-list-item-content>
           </template>
           <template #append>
-            <v-icon v-if="studyAuto.length" color="primary" @click="studyAuto = []"
-              >mdi-close</v-icon
-            >
+            <v-icon v-if="studyAuto.length" color="primary" @click="studyAuto = []">
+              mdi-close
+            </v-icon>
           </template>
         </v-autocomplete>
       </v-col>
@@ -53,9 +53,9 @@
       <v-col cols="12" lg="8">
         <v-card v-for="study in studies" :key="study.id" class="study-card">
           <v-card-title>{{ study.title }}</v-card-title>
-          <v-card-subtitle v-if="study.principal_investigator">{{
-            study.principal_investigator
-          }}</v-card-subtitle>
+          <v-card-subtitle v-if="study.principal_investigator">
+            {{ study.principal_investigator }}
+          </v-card-subtitle>
           <v-card-text v-if="study.description">{{ study.description }}</v-card-text>
           <v-card-actions>
             <v-btn
@@ -75,17 +75,30 @@
 </template>
 
 <script>
+import { computed } from 'vue';
+
+import { useCaseStudies } from '@/api';
 import helpers from '@/helpers';
 
 export default {
-  name: 'Studies',
+  name: 'CaseStudies',
   mixins: [helpers],
+  setup() {
+    const caseStudiesQuery = useCaseStudies();
+
+    const isLoading = computed(() => caseStudiesQuery.isInitialLoading.value);
+
+    const studies = computed(() => caseStudiesQuery.data.value?.results ?? []);
+
+    return {
+      isLoading,
+      studies,
+    };
+  },
   data: () => ({
-    studies: [],
     studySearch: [],
     studyAuto: [],
     textInput: '',
-    loading: false,
   }),
   watch: {
     textInput(val) {
@@ -170,22 +183,6 @@ export default {
       },
       deep: true,
     },
-  },
-  mounted() {
-    const address = `${import.meta.env.VITE_APP_MMP_API_BASE_URL}/api/usecase/?format=json`;
-    const prefetched = this.$store.state.fetchedResults[address];
-
-    if (prefetched) {
-      this.studies = prefetched.results;
-    } else {
-      fetch(address)
-        .then((res) => res.json())
-        .then((res) => {
-          console.log('studies', res);
-          this.$store.commit('addToResults', { req: address, res });
-          this.studies = res.results;
-        });
-    }
   },
 };
 </script>

--- a/src/components/Studies.vue
+++ b/src/components/Studies.vue
@@ -62,7 +62,7 @@
               text
               :to="{
                 name: 'Case Study',
-                params: { id: study.id, query: addParamsToQuery() },
+                params: { id: study.id, query: $route.query },
               }"
             >
               Read More

--- a/src/lib/is-not-nullable.ts
+++ b/src/lib/is-not-nullable.ts
@@ -1,0 +1,3 @@
+export function isNotNullable<T>(value: T): value is NonNullable<T> {
+  return value != null;
+}

--- a/src/lib/search/is-same-item.ts
+++ b/src/lib/search/is-same-item.ts
@@ -1,0 +1,5 @@
+import type { Item } from '@/lib/search/types';
+
+export function isSameItem(a: Item, b: Item): boolean {
+  return a.id === b.id && a.kind === b.kind;
+}

--- a/src/lib/search/types.ts
+++ b/src/lib/search/types.ts
@@ -1,0 +1,3 @@
+import type { GetAutoComplete } from '@/api';
+
+export type Item = GetAutoComplete.Response['results'][number];

--- a/src/lib/search/unique-items.ts
+++ b/src/lib/search/unique-items.ts
@@ -1,0 +1,6 @@
+import { isSameItem } from '@/lib/search/is-same-item';
+import type { Item } from '@/lib/search/types';
+
+export function uniqueItems(a: Array<Item>, b: Array<Item>): Array<Item> {
+  return [...a, ...b.filter((item) => !a.some((i) => isSameItem(item, i)))];
+}

--- a/src/lib/use-store.ts
+++ b/src/lib/use-store.ts
@@ -1,0 +1,8 @@
+import { getCurrentInstance } from 'vue';
+
+import type Store from '@/plugins/store';
+
+export function useStore(): typeof Store {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  return getCurrentInstance()!.proxy.$store!;
+}

--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import VueRouter from 'vue-router';
 
 import AuthorDetail from '@/components/AuthorDetail';
+import CaseStudies from '@/components/CaseStudies';
 import CaseStudy from '@/components/CaseStudy';
 import CompareAuthors from '@/components/CompareAuthors';
 import Debug from '@/components/Debug';
@@ -16,7 +17,6 @@ import Map from '@/components/MapWrapper';
 import PassageDetail from '@/components/PassageDetail';
 import PlaceDetail from '@/components/PlaceDetail';
 import SpatialDetail from '@/components/SpatialDetail';
-import Studies from '@/components/Studies';
 import WordCloudWrapper from '@/components/WordCloudWrapper';
 
 Vue.use(VueRouter);
@@ -34,8 +34,8 @@ const routes = [
   },
   {
     path: '/studies/',
-    name: 'Studies',
-    component: Studies,
+    name: 'Case Studies',
+    component: CaseStudies,
   },
   {
     path: '/studies/:id',


### PR DESCRIPTION
refactor data fetching to use api client hooks.

follow-up should (i) centralize search-filter sync with url searchparams, (ii) consistently use data fetching wrapper components - currently we have a few places where components accept search filters both via props, and via url searchparams (iii) convert to composition api and typescript.

also, we currently only properly paginate in the "list passages" and "list all entities" data-table views. all other requests implicitly rely on the fact that all results will be included on the first page. are we fine with that? should we bump `limit`?

also, some detail panels seem to accept multiple ids via path params - not sure if this is actually intentional?
- spatial detail accepts: /explore/map/spatial/%5B44,102,111,112%5D (comma separated, wrapped in square brackets)
- keyword detail accepts: /explore/graph/detail/184+317+261+172+306 (comma separated)

still need to be converted (leave these for a follow-up):
- [ ] CompareAuthors
- [ ] GraphWrapperBeta
- [ ] InterfaceWrapper
- [ ] List
- [ ] ListAll