### PR TITLE
fix: update autocomplete endpoint

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -68,8 +68,7 @@ const options: RequestOptions = { responseType: 'json' };
 
 export namespace GetAutoComplete {
   export type SearchParams = {
-    /** Must be at least 3 characters. */
-    q: string;
+    q?: string;
     kind?: Array<ResourceKind>;
   };
   export type Response = { q: string; filter_on: Array<ResourceKind> } & PaginatedResponse<{

--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -957,7 +957,7 @@ export function useAutoComplete(
     queryKey: createKey('autocomplete', 'list', searchParams),
     queryFn: ({ queryKey: [, , searchParams] }) => {
       // @ts-expect-error Upstream type error.
-      return api.getAutoComplete(assertParams(searchParams, ['q']));
+      return api.getAutoComplete(searchParams);
     },
     ...getQueryOptions(options),
   });

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -86,4 +86,4 @@ export type FeatureWithBoundingBox<
   bbox: [number, number, number, number];
 };
 
-export type ResourceKind = 'autor' | 'ort' | 'text' | 'stelle' | 'keyword' | 'geojsonlayer';
+export type ResourceKind = 'autor' | 'ort' | 'text' | 'stelle' | 'keyword' | 'usecase';


### PR DESCRIPTION
update autocomplete endpoint in api client: search term is no longer required, default config searches case studies, not geojson layers.

cf. https://github.com/acdh-oeaw/mmp/pull/163